### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -1,4 +1,6 @@
 name: Broken link check
+permissions:
+  contents: read
 on: 
   schedule:
   - cron: "0 4 1 * *"


### PR DESCRIPTION
Potential fix for [https://github.com/funkysi1701/funkysi1701.github.io/security/code-scanning/28](https://github.com/funkysi1701/funkysi1701.github.io/security/code-scanning/28)

To correct the issue and follow the principle of least privilege, an explicit `permissions` key should be added. Since the workflow only checks external links and does not appear to require any write access to the repository, the minimal required permission is almost certainly `contents: read`. This should be set either at the root of the workflow (after the `name:` and `on:` keys) to apply to all jobs or at the job level specifically for `broken_link_checker_job`. The best practice is to add it at the top, so all jobs default to read-only unless otherwise specified. No other edits or method changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
