### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/themes/hugo-theme-bootstrap/src/main/js/code-block.ts
+++ b/themes/hugo-theme-bootstrap/src/main/js/code-block.ts
@@ -42,7 +42,7 @@ class CodeBlock {
     if (lang) {
       const element = document.createElement('div');
       element.className = 'lang';
-      element.innerHTML = lang;
+      element.textContent = lang;
       this.wrapper.appendChild(element);
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/funkysi1701/funkysi1701.github.io/security/code-scanning/2](https://github.com/funkysi1701/funkysi1701.github.io/security/code-scanning/2)

The vulnerable pattern is directly assigning a value retrieved from a DOM attribute (`lang`) to `innerHTML`, which can unintentionally unescape and execute malicious content. To resolve this, you should assign the value with contextual encoding/escaping. In this case, set the DOM node's `textContent` property instead of `innerHTML`, which treats the input as plain text rather than HTML. The only line to change is in the `appendLang` method (line 45); replace `element.innerHTML = lang;` with `element.textContent = lang;`. This prevents execution of any HTML or script possibly present in `lang`. No new imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
