### PR TITLE
fix descriptions

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,25 +1,35 @@
 {{- partial "head/favicons" . -}}
-{{- $keywords := "" -}}
+{{- $keywords := $.Site.Params.keywords | default "" -}}
 {{- if .IsPage -}}
-  {{- $filtered := slice -}}
-  {{- range .Keywords -}}
-    {{- $t := strings.TrimSpace . -}}
-    {{- if ne $t "" -}}
-      {{- $filtered = $filtered | append $t -}}
+  {{- with .Keywords -}}
+    {{- $joined := delimit . ", " -}}
+    {{- if ne $joined ", " -}}
+      {{- $keywords = $joined -}}
     {{- end -}}
   {{- end -}}
-  {{- if $filtered -}}
-    {{- $keywords = delimit $filtered ", " -}}
+{{- end -}}
+{{- $pageDesc := "" -}}
+{{- if .IsPage -}}
+  {{- with .Params.description -}}
+    {{- $pageDesc = . -}}
   {{- else -}}
-    {{- $keywords = $.Site.Params.keywords | default "" -}}
+    {{- with .Description -}}
+      {{- $pageDesc = . -}}
+    {{- else -}}
+      {{- $pageDesc = .Summary -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $pageDesc = $pageDesc | plainify | htmlUnescape -}}
+  {{- if not $pageDesc -}}
+    {{- $pageDesc = .Title | plainify | htmlUnescape -}}
   {{- end -}}
 {{- else -}}
-  {{- $keywords = $.Site.Params.keywords | default "" -}}
+  {{- $pageDesc = printf "%s - %s" .Title ($.Site.Params.description | default "") | plainify | htmlUnescape -}}
 {{- end -}}
 {{- with $keywords -}}
 <meta name="keywords" content="{{ . }}" />
 {{- end -}}
-<meta name="description" content="{{ if .IsPage }}{{ if .Description }}{{ .Description | plainify | htmlUnescape }}{{ else }}{{ .Summary | plainify | htmlUnescape }}{{ end }}{{ else }}{{ .Title }} - {{ $.Site.Params.description }}{{ end }}" />
+<meta name="description" content="{{ $pageDesc }}" />
 <meta name="fediverse:creator" content="@funkysi1701@hachyderm.io">
 {{ template "_internal/opengraph.html" . }}
 {{- template "_internal/twitter_cards.html" . -}}
@@ -37,19 +47,22 @@
 {{- $websiteJSON := $website | jsonify -}}
 <script type="application/ld+json">{{- $websiteJSON | safeJS -}}</script>
 {{- else if .IsPage -}}
-{{- $desc := .Summary | plainify | htmlUnescape -}}
-{{- with .Description -}}{{- $desc = . | plainify | htmlUnescape -}}{{- end -}}
+{{- $desc := $pageDesc -}}
 {{- $iso8601 := "2006-01-02T15:04:05Z07:00" -}}
 {{- $published := or .PublishDate .Date -}}
 {{- $modified := or .Lastmod .Date -}}
 {{- $image := absURL "/images/1922276.jpg" -}}
-{{- $cover := strings.TrimSpace (.Params.cover | default "") -}}
+{{- $cover := .Params.cover | default "" -}}
 {{- if ne $cover "" -}}
   {{- $image = absURL $cover -}}
-{{- else if and .Params.images (gt (len .Params.images) 0) -}}
-  {{- $firstImage := strings.TrimSpace (index .Params.images 0 | default "") -}}
+{{- else if isset .Params "images" -}}
+  {{- with .Params.images -}}
+  {{- if gt (len .) 0 -}}
+  {{- $firstImage := index . 0 | default "" -}}
   {{- if ne $firstImage "" -}}
     {{- $image = absURL $firstImage -}}
+  {{- end -}}
+  {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- $authorName := .Params.author | default $.Site.Params.author.name -}}

--- a/layouts/partials/head/meta/robots.html
+++ b/layouts/partials/head/meta/robots.html
@@ -1,6 +1,10 @@
 {{- $content := default $.Site.Params.metaRobots .Params.metaRobots -}}
-{{- if and (not (isset .Params "metarobots")) .IsHome .Paginator (gt .Paginator.PageNumber 1) -}}
-  {{- $hr := strings.TrimSpace (default "" $.Site.Params.homePaginationMetaRobots) -}}
+{{- $paginatorPage := 1 -}}
+{{- if .Paginator -}}
+  {{- $paginatorPage = .Paginator.PageNumber -}}
+{{- end -}}
+{{- if and (not (isset .Params "metarobots")) .IsHome (gt $paginatorPage 1) -}}
+  {{- $hr := default "" $.Site.Params.homePaginationMetaRobots -}}
   {{- if ne $hr "" -}}
     {{- $content = $hr -}}
   {{- end -}}

--- a/tests/blog-posts-content/single-blog-post.spec.ts
+++ b/tests/blog-posts-content/single-blog-post.spec.ts
@@ -72,7 +72,9 @@ test.describe('Blog Posts and Content', () => {
       const description = page.locator('meta[name="description"]');
       await expect(description).toHaveCount(1);
       const content = await description.getAttribute('content');
-      expect(content?.trim()).toBe(expectedDescription);
+      expect(content ?? '').toContain(
+        'For the second year running, I had the privilege of volunteering at NDC London',
+      );
       expect(content?.length ?? 0).toBeGreaterThanOrEqual(110);
     });
 

--- a/tests/blog-posts-content/single-blog-post.spec.ts
+++ b/tests/blog-posts-content/single-blog-post.spec.ts
@@ -66,5 +66,16 @@ test.describe('Blog Posts and Content', () => {
       await expect(page.locator('text=/reading time|min read|\d+ min/i').first()).toBeVisible();
     });
 
+    await test.step('Verify SEO meta description from front matter', async () => {
+      const description = page.locator('meta[name="description"]');
+      await expect(description).toHaveCount(1);
+      await expect(description).toHaveAttribute(
+        'content',
+        /For the second year running, I had the privilege of volunteering at NDC London/i,
+      );
+      const content = await description.getAttribute('content');
+      expect(content?.length ?? 0).toBeGreaterThanOrEqual(110);
+    });
+
   });
 });

--- a/tests/blog-posts-content/single-blog-post.spec.ts
+++ b/tests/blog-posts-content/single-blog-post.spec.ts
@@ -67,13 +67,12 @@ test.describe('Blog Posts and Content', () => {
     });
 
     await test.step('Verify SEO meta description from front matter', async () => {
+      const expectedDescription =
+        'For the second year running, I had the privilege of volunteering at NDC London';
       const description = page.locator('meta[name="description"]');
       await expect(description).toHaveCount(1);
-      await expect(description).toHaveAttribute(
-        'content',
-        /For the second year running, I had the privilege of volunteering at NDC London/i,
-      );
       const content = await description.getAttribute('content');
+      expect(content?.trim()).toBe(expectedDescription);
       expect(content?.length ?? 0).toBeGreaterThanOrEqual(110);
     });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> SEO and head-template changes with a regression test; no auth, data, or security-sensitive logic.
> 
> **Overview**
> **Meta descriptions** are now built once as `$pageDesc` in `head.html`, with pages preferring front matter `description`, then Hugo’s `.Description`, then `.Summary`, then the title. The `<meta name="description">` tag and BlogPosting JSON-LD both use that same value so SEO and structured data stay aligned.
> 
> **Keywords** on pages are simplified to join `.Keywords` when present, otherwise site defaults. **Article images** in JSON-LD use `isset` on `images` instead of length checks with extra trimming.
> 
> **Home pagination robots** in `robots.html` no longer assumes `.Paginator` exists; page number defaults to 1 and only overrides when a paginator is present, avoiding bad meta on non-paginated home views.
> 
> A Playwright step asserts the NDC London post’s meta description matches front matter and is at least 110 characters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2a766a21ea1e24a56c4b4380d43fb6df599104e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->