### PR TITLE
fix

### DIFF
--- a/layouts/partials/head/meta/robots.html
+++ b/layouts/partials/head/meta/robots.html
@@ -1,9 +1,6 @@
 {{- $content := default $.Site.Params.metaRobots .Params.metaRobots -}}
-{{- $paginatorPage := 1 -}}
-{{- if .Paginator -}}
-  {{- $paginatorPage = .Paginator.PageNumber -}}
-{{- end -}}
-{{- if and (not (isset .Params "metarobots")) .IsHome (gt $paginatorPage 1) -}}
+{{- $isPaginatedHome := and .IsHome (strings.Contains .RelPermalink "/page/") -}}
+{{- if and (not (isset .Params "metarobots")) $isPaginatedHome -}}
   {{- $hr := default "" $.Site.Params.homePaginationMetaRobots -}}
   {{- if ne $hr "" -}}
     {{- $content = $hr -}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small SEO partial change with no auth, data, or runtime logic beyond robots meta on paginated home URLs.
> 
> **Overview**
> **Paginated home pages** now get the optional `homePaginationMetaRobots` value (e.g. `noindex,follow`) by detecting URLs whose path contains `/page/` on the home template, instead of relying on `.Paginator.PageNumber`.
> 
> That replaces Hugo paginator state, which may not be available when the robots partial runs, so paginated home listings were previously treated like page 1 for robots meta.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 892a607d4854743b3e413892c5480e5d4205569e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->