### PR TITLE
try this

### DIFF
--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="{{ site.Language.LanguageCode | default "en-gb" }}">
+<head>
+  <title>{{ .Title }}</title>
+  <link rel="canonical" href="{{ .Permalink }}">
+  {{- $pageDesc := "" -}}
+  {{- with .Params.description -}}
+    {{- $pageDesc = . -}}
+  {{- else -}}
+    {{- with .Description -}}
+      {{- $pageDesc = . -}}
+    {{- else -}}
+      {{- $pageDesc = .Summary -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $pageDesc = $pageDesc | plainify | htmlUnescape -}}
+  {{- if not $pageDesc -}}
+    {{- $pageDesc = .Title | plainify | htmlUnescape -}}
+  {{- end -}}
+  <meta name="description" content="{{ $pageDesc }}">
+  <meta name="robots" content="noindex,follow">
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url={{ .Permalink }}">
+</head>
+</html>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Static HTML template for Hugo alias redirects only; no application logic, auth, or data handling.
> 
> **Overview**
> Adds a custom Hugo **`layouts/alias.html`** so URL alias pages no longer use the default minimal redirect stub.
> 
> Alias URLs now emit a **canonical** link to the real permalink, a **meta description** (from front matter `description`, page description, summary, or title), and **`noindex,follow`** so search engines should not index duplicate alias paths while still passing link equity. Visitors are sent to the target URL immediately via a **meta refresh** to `{{ .Permalink }}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91cff0f69813d5c857f5833139374163d483dba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->