### PR TITLE
add missing H1

### DIFF
--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -22,4 +22,7 @@
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url={{ .Permalink }}">
 </head>
+<body>
+  <h1>{{ .Title }}</h1>
+</body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small markup change on noindex redirect pages with no auth, data, or routing logic impact.
> 
> **Overview**
> The Hugo **alias** redirect template (`layouts/alias.html`) now includes a `<body>` with an `<h1>` set to `{{ .Title }}`, so alias pages expose a visible heading instead of an empty document before the meta refresh redirect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71ade92bb32c286ff7826b40d7f6c3207d87757. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->