### PR TITLE
<h3> used without a preceding <h2> (heading level skipped)

### DIFF
--- a/layouts/partials/header/settings.html
+++ b/layouts/partials/header/settings.html
@@ -1,0 +1,16 @@
+<button class="navbar-settings" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasSettings"
+  aria-controls="offcanvasSettings" aria-label="Toggle settings">
+  <i class="fas fa-ellipsis-v"></i>
+</button>
+
+<div class="offcanvas offcanvas-end surface h-100" tabindex="-1" id="offcanvasSettings" aria-labelledby="offcanvasSettings">
+  <div class="offcanvas-header">
+    <h2 class="offcanvas-title">{{ i18n "settings" }}</h2>
+    <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="offcanvas" aria-label="Close">
+      <i class="fas fa-times"></i>
+    </button>
+  </div>
+  <div class="offcanvas-body d-flex flex-column">
+    {{- partial "header/settings/index" . -}}
+  </div>
+</div>

--- a/layouts/partials/header/social-share.html
+++ b/layouts/partials/header/social-share.html
@@ -1,0 +1,20 @@
+{{- if (default true .Site.Params.socialShare) -}}
+<div class="offcanvas offcanvas-bottom surface" tabindex="-1" id="offcanvasSocialShare" aria-labelledby="offcanvasSocialShare">
+  <div class="offcanvas-header">
+    <h2 class="offcanvas-title">Share</h2>
+    <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="offcanvas" aria-label="Close">
+      <i class="fas fa-times"></i>
+    </button>
+  </div>
+  <div class="offcanvas-body">
+    <a class="btn btn-sm btn-outline-primary social-share-button" rel="noopener noreferrer" aria-label="Twitter Share Button"
+      target="_blank" href="https://twitter.com/intent/tweet?title={{ .Title }}&url={{ .Permalink | absURL }}">
+      <i class="fab fa-fw fa-twitter"></i> Twitter
+    </a>
+    <a class="btn btn-sm btn-outline-primary social-share-button" rel="noopener noreferrer" aria-label="Facebook Share Button"
+      target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{ .Permalink | absURL }}">
+      <i class="fab fa-fw fa-facebook-f"></i> Facebook
+    </a>
+  </div>
+</div>
+{{- end -}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small Hugo layout additions with no auth, data, or business-logic changes; only markup and share URLs.
> 
> **Overview**
> Adds two new header partials that wrap UI in Bootstrap offcanvas panels with proper **`<h2>`** titles in the offcanvas headers.
> 
> **Settings** (`settings.html`): a navbar control opens an end-side offcanvas whose body renders `header/settings/index`.
> 
> **Social share** (`social-share.html`): when `socialShare` is enabled (default on), a bottom offcanvas exposes Twitter and Facebook share links using the page title and absolute permalink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a855abe75c25e0df790596a056a876cf6169fe24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->