### PR TITLE
fix

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -3,9 +3,9 @@
   <div class="container">
     <div class="row card component">
       <div class="card-header">
-        <h2 class="card-title">
+        <h1 class="card-title">
           Search
-        </h2>
+        </h1>
       </div>
       <div class="card-body">
         <div class="post-meta mb-3">

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<html lang="{{ site.Language.LanguageCode | default "en-gb" }}">
+<html lang="{{ site.LanguageCode }}">
 <head>
+  <meta charset="utf-8">
   <title>{{ .Title }}</title>
   <link rel="canonical" href="{{ .Permalink }}">
   {{- $pageDesc := "" -}}
@@ -17,9 +18,35 @@
   {{- if not $pageDesc -}}
     {{- $pageDesc = .Title | plainify | htmlUnescape -}}
   {{- end -}}
+  {{- $title := .Title | plainify | htmlUnescape -}}
+  {{- $image := absURL "/images/1922276.jpg" -}}
+  {{- $cover := .Params.cover | default "" -}}
+  {{- if ne $cover "" -}}
+    {{- $image = absURL $cover -}}
+  {{- else if isset .Params "images" -}}
+    {{- with .Params.images -}}
+      {{- if gt (len .) 0 -}}
+        {{- $firstImage := index . 0 | default "" -}}
+        {{- if ne $firstImage "" -}}
+          {{- $image = absURL $firstImage -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
   <meta name="description" content="{{ $pageDesc }}">
   <meta name="robots" content="noindex,follow">
-  <meta charset="utf-8">
+  <meta property="og:title" content="{{ $title }}">
+  <meta property="og:description" content="{{ $pageDesc }}">
+  <meta property="og:url" content="{{ .Permalink }}">
+  <meta property="og:image" content="{{ $image }}">
+  <meta property="og:type" content="article">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ $title }}">
+  <meta name="twitter:description" content="{{ $pageDesc }}">
+  <meta name="twitter:image" content="{{ $image }}">
+  {{- with site.Params.social.twitter -}}
+  <meta name="twitter:site" content="@{{ . }}">
+  {{- end -}}
   <meta http-equiv="refresh" content="0; url={{ .Permalink }}">
 </head>
 <body>

--- a/layouts/partials/header/settings.html
+++ b/layouts/partials/header/settings.html
@@ -3,9 +3,9 @@
   <i class="fas fa-ellipsis-v"></i>
 </button>
 
-<div class="offcanvas offcanvas-end surface h-100" tabindex="-1" id="offcanvasSettings" aria-labelledby="offcanvasSettings">
+<div class="offcanvas offcanvas-end surface h-100" tabindex="-1" id="offcanvasSettings" aria-labelledby="offcanvasSettingsLabel">
   <div class="offcanvas-header">
-    <h2 class="offcanvas-title">{{ i18n "settings" }}</h2>
+    <p class="offcanvas-title mb-0" id="offcanvasSettingsLabel">{{ i18n "settings" }}</p>
     <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="offcanvas" aria-label="Close">
       <i class="fas fa-times"></i>
     </button>

--- a/layouts/partials/header/social-share.html
+++ b/layouts/partials/header/social-share.html
@@ -1,7 +1,7 @@
 {{- if (default true .Site.Params.socialShare) -}}
-<div class="offcanvas offcanvas-bottom surface" tabindex="-1" id="offcanvasSocialShare" aria-labelledby="offcanvasSocialShare">
+<div class="offcanvas offcanvas-bottom surface" tabindex="-1" id="offcanvasSocialShare" aria-labelledby="offcanvasSocialShareLabel">
   <div class="offcanvas-header">
-    <h2 class="offcanvas-title">Share</h2>
+    <p class="offcanvas-title mb-0" id="offcanvasSocialShareLabel">Share</p>
     <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="offcanvas" aria-label="Close">
       <i class="fas fa-times"></i>
     </button>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation and SEO meta only in static Hugo templates; no auth, data, or runtime logic changes.
> 
> **Overview**
> Improves **page semantics and accessibility** in Hugo layouts: the search page title moves from `h2` to **`h1`**, and settings/social offcanvas panels wire **`aria-labelledby`** to real label elements (`offcanvasSettingsLabel`, `offcanvasSocialShareLabel`) by replacing offcanvas `h2` titles with styled **`p.offcanvas-title`** elements.
> 
> **Alias redirect pages** (`layouts/alias.html`) get richer head metadata while staying `noindex`: `lang` uses `site.LanguageCode`, charset is ordered earlier, and **Open Graph / Twitter** tags are added with title, description, URL, and an image resolved from `cover`, `images`, or a site default—still with canonical link and meta refresh to the target permalink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3321d683d1aab99a71c90feb955720944c4ef8d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->