### PR TITLE
fix

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,39 @@
+<!doctype html>
+{{- $color := $.Site.Params.color -}}
+<html lang="{{ .Lang }}"{{ with $.Site.Params.palette }} data-palette="{{ . }}"{{ end }}
+  {{ if in (slice "light" "dark") $color }}{{ printf " data-mode=\"%s\"" $color | safeHTMLAttr }}{{ end }}>
+  <head>
+    {{- if $.Site.Params.enableGatekeeper -}}
+    <script data-cfasync="false" src="https://cmp.gatekeeperconsent.com/min.js"></script>
+    <script data-cfasync="false" src="https://the.gatekeeperconsent.com/cmp.min.js"></script>
+    <script async src="//www.ezojs.com/ezoic/sa.min.js"></script>
+    <script>
+        window.ezstandalone = window.ezstandalone || {};
+        ezstandalone.cmd = ezstandalone.cmd || [];
+    </script>
+    {{- end -}}
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{- block "title" . -}}{{- partial "head/title" . -}}{{- end -}}</title>
+    {{- partial "head.html" . -}}
+    {{- block "head-end" . -}}{{- end -}}
+    {{- partial "hooks/head-end" . -}}
+    {{- partial "head/canonical" . -}}
+  </head>
+  <body>
+    {{- $bootstrapScript := resources.Get "bootstrap/template.js" | resources.ExecuteAsTemplate "js/bootstrap.js" . | minify -}}
+    <script>
+      {{- $bootstrapScript.Content | safeJS -}}
+    </script>
+    {{- partial "header.html" . -}}
+    {{- partial "hooks/main-begin" . -}}
+    <main role="main" class="container{{ if default false .Site.Params.fullWidth }}-fluid{{ end }}">
+      <div class="row content">
+        {{- block "content" . -}}{{- end -}}
+      </div>
+    </main>
+    {{- partial "hooks/main-end" . -}}
+    {{- partial "footer.html" . -}}
+    {{- partial "body-end" . -}}
+  </body>
+</html>

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>{{ .Title }}</title>
-  <link rel="canonical" href="{{ .Permalink }}">
   {{- $pageDesc := "" -}}
   {{- with .Params.description -}}
     {{- $pageDesc = . -}}
@@ -47,6 +46,7 @@
   {{- with site.Params.social.twitter -}}
   <meta name="twitter:site" content="@{{ . }}">
   {{- end -}}
+  {{- partial "head/schema-blog-posting" (dict "page" .) -}}
   <meta http-equiv="refresh" content="0; url={{ .Permalink }}">
 </head>
 <body>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -47,49 +47,7 @@
 {{- $websiteJSON := $website | jsonify -}}
 <script type="application/ld+json">{{- $websiteJSON | safeJS -}}</script>
 {{- else if .IsPage -}}
-{{- $desc := $pageDesc -}}
-{{- $iso8601 := "2006-01-02T15:04:05Z07:00" -}}
-{{- $published := or .PublishDate .Date -}}
-{{- $modified := or .Lastmod .Date -}}
-{{- $image := absURL "/images/1922276.jpg" -}}
-{{- $cover := .Params.cover | default "" -}}
-{{- if ne $cover "" -}}
-  {{- $image = absURL $cover -}}
-{{- else if isset .Params "images" -}}
-  {{- with .Params.images -}}
-  {{- if gt (len .) 0 -}}
-  {{- $firstImage := index . 0 | default "" -}}
-  {{- if ne $firstImage "" -}}
-    {{- $image = absURL $firstImage -}}
-  {{- end -}}
-  {{- end -}}
-  {{- end -}}
-{{- end -}}
-{{- $authorName := .Params.author | default $.Site.Params.author.name -}}
-{{- $author := dict "@type" "Person" "name" $authorName "url" (absURL "about") -}}
-{{- $publisher := dict "@type" "Person" "name" $.Site.Params.author.name "url" .Site.BaseURL -}}
-{{- $mainEntityOfPage := dict "@type" "WebPage" "@id" .Permalink -}}
-{{- $article := dict "@type" "BlogPosting" "@id" (printf "%s#article" .Permalink) "headline" .Title "description" $desc "url" .Permalink "datePublished" ($published.Format $iso8601) "dateModified" ($modified.Format $iso8601) "image" $image "author" $author "publisher" $publisher "wordCount" .WordCount "mainEntityOfPage" $mainEntityOfPage -}}
-{{- $sectionTitles := slice -}}
-{{- range .GetTerms "categories" -}}
-  {{- $sectionTitles = $sectionTitles | append .Title -}}
-{{- end -}}
-{{- if gt (len $sectionTitles) 0 -}}
-  {{- $article = merge $article (dict "articleSection" (delimit $sectionTitles ", ")) -}}
-{{- end -}}
-{{- $structured := dict -}}
-{{- if eq .Section "posts" -}}
-  {{- $schemaScratch := newScratch -}}
-  {{- partial "head/breadcrumb-schema" (dict "page" . "target" $schemaScratch) -}}
-  {{- $breadcrumb := $schemaScratch.Get "schema" -}}
-  {{- if $breadcrumb -}}
-    {{- $structured = dict "@context" "https://schema.org" "@graph" (slice $article $breadcrumb) -}}
-  {{- else -}}
-    {{- $structured = merge $article (dict "@context" "https://schema.org") -}}
-  {{- end -}}
-{{- else -}}
-  {{- $structured = merge $article (dict "@context" "https://schema.org") -}}
-{{- end -}}
-{{- $structuredJSON := $structured | jsonify -}}
-<script type="application/ld+json">{{- $structuredJSON | safeJS -}}</script>
+{{- partial "head/schema-blog-posting" (dict "page" .) -}}
+{{- else if or (eq .Kind "term") (eq .Kind "taxonomy") -}}
+{{- partial "head/schema-collection-page" (dict "page" .) -}}
 {{- end -}}

--- a/layouts/partials/head/canonical.html
+++ b/layouts/partials/head/canonical.html
@@ -1,0 +1,14 @@
+{{/* Canonical URL: match the page being viewed (including /page/N/ on paginated lists). */}}
+{{ with .Params.relcanonical }}
+<link rel="canonical" href="{{ . | relLangURL }}" itemprop="url" />
+{{ else }}
+  {{- $canonical := .Permalink -}}
+  {{- with .Paginator -}}
+    {{- if gt .PageNumber 1 -}}
+      {{- $canonical = .URL | absLangURL -}}
+    {{- end -}}
+  {{- else if strings.Contains .RelPermalink "/page/" -}}
+    {{- $canonical = .RelPermalink | absLangURL -}}
+  {{- end -}}
+<link rel="canonical" href="{{ $canonical }}" itemprop="url" />
+{{ end }}

--- a/layouts/partials/head/schema-blog-posting.html
+++ b/layouts/partials/head/schema-blog-posting.html
@@ -1,0 +1,58 @@
+{{- $page := .page -}}
+{{- $pageDesc := "" -}}
+{{- with $page.Params.description -}}
+  {{- $pageDesc = . -}}
+{{- else -}}
+  {{- with $page.Description -}}
+    {{- $pageDesc = . -}}
+  {{- else -}}
+    {{- $pageDesc = $page.Summary -}}
+  {{- end -}}
+{{- end -}}
+{{- $pageDesc = $pageDesc | plainify | htmlUnescape -}}
+{{- if not $pageDesc -}}
+  {{- $pageDesc = $page.Title | plainify | htmlUnescape -}}
+{{- end -}}
+{{- $iso8601 := "2006-01-02T15:04:05Z07:00" -}}
+{{- $published := or $page.PublishDate $page.Date -}}
+{{- $modified := or $page.Lastmod $page.Date -}}
+{{- $image := absURL "/images/1922276.jpg" -}}
+{{- $cover := $page.Params.cover | default "" -}}
+{{- if ne $cover "" -}}
+  {{- $image = absURL $cover -}}
+{{- else if isset $page.Params "images" -}}
+  {{- with $page.Params.images -}}
+    {{- if gt (len .) 0 -}}
+      {{- $firstImage := index . 0 | default "" -}}
+      {{- if ne $firstImage "" -}}
+        {{- $image = absURL $firstImage -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $authorName := $page.Params.author | default $page.Site.Params.author.name -}}
+{{- $author := dict "@type" "Person" "name" $authorName "url" (absURL "about") -}}
+{{- $publisher := dict "@type" "Person" "name" $page.Site.Params.author.name "url" $page.Site.BaseURL -}}
+{{- $mainEntityOfPage := dict "@type" "WebPage" "@id" $page.Permalink -}}
+{{- $article := dict "@type" "BlogPosting" "@id" (printf "%s#article" $page.Permalink) "headline" $page.Title "description" $pageDesc "url" $page.Permalink "datePublished" ($published.Format $iso8601) "dateModified" ($modified.Format $iso8601) "image" $image "author" $author "publisher" $publisher "wordCount" $page.WordCount "mainEntityOfPage" $mainEntityOfPage -}}
+{{- $sectionTitles := slice -}}
+{{- range $page.GetTerms "categories" -}}
+  {{- $sectionTitles = $sectionTitles | append .Title -}}
+{{- end -}}
+{{- if gt (len $sectionTitles) 0 -}}
+  {{- $article = merge $article (dict "articleSection" (delimit $sectionTitles ", ")) -}}
+{{- end -}}
+{{- $structured := dict -}}
+{{- if eq $page.Section "posts" -}}
+  {{- $schemaScratch := newScratch -}}
+  {{- partial "head/breadcrumb-schema" (dict "page" $page "target" $schemaScratch) -}}
+  {{- $breadcrumb := $schemaScratch.Get "schema" -}}
+  {{- if $breadcrumb -}}
+    {{- $structured = dict "@context" "https://schema.org" "@graph" (slice $article $breadcrumb) -}}
+  {{- else -}}
+    {{- $structured = merge $article (dict "@context" "https://schema.org") -}}
+  {{- end -}}
+{{- else -}}
+  {{- $structured = merge $article (dict "@context" "https://schema.org") -}}
+{{- end -}}
+<script type="application/ld+json">{{- $structured | jsonify | safeJS -}}</script>

--- a/layouts/partials/head/schema-collection-page.html
+++ b/layouts/partials/head/schema-collection-page.html
@@ -1,0 +1,20 @@
+{{- $page := .page -}}
+{{- $pageDesc := printf "%s - %s" $page.Title ($page.Site.Params.description | default "") | plainify | htmlUnescape -}}
+{{- $pageURL := $page.Permalink -}}
+{{- with $page.Paginator -}}
+  {{- if gt .PageNumber 1 -}}
+    {{- $pageURL = .URL | absLangURL -}}
+  {{- end -}}
+{{- else if strings.Contains $page.RelPermalink "/page/" -}}
+  {{- $pageURL = $page.RelPermalink | absLangURL -}}
+{{- end -}}
+{{- $website := dict "@type" "WebSite" "@id" (printf "%s#website" $page.Site.Home.Permalink) "name" $page.Site.Title "url" $page.Site.Home.Permalink -}}
+{{- $collection := dict "@type" "CollectionPage" "@id" (printf "%s#webpage" $pageURL) "url" $pageURL "name" $page.Title "description" $pageDesc "isPartOf" $website -}}
+{{- $graph := slice $collection -}}
+{{- $schemaScratch := newScratch -}}
+{{- partial "head/breadcrumb-schema" (dict "page" $page "target" $schemaScratch) -}}
+{{- with $schemaScratch.Get "schema" -}}
+  {{- $graph = $graph | append . -}}
+{{- end -}}
+{{- $structured := dict "@context" "https://schema.org" "@graph" $graph -}}
+<script type="application/ld+json">{{- $structured | jsonify | safeJS -}}</script>

--- a/layouts/partials/head/title.html
+++ b/layouts/partials/head/title.html
@@ -31,6 +31,8 @@
   {{- $paginator = .Paginate (union $pinnedPosts $allPosts) -}}
 {{- else if eq .Kind "taxonomy" -}}
   {{- $paginator = .Paginate .Pages (default 10 $.Site.Params.taxonomyPaginate) -}}
+{{- else if eq .Kind "term" -}}
+  {{- $paginator = .Paginate .Pages (default 10 $.Site.Params.taxonomyPaginate) -}}
 {{- else if eq .Kind "section" -}}
   {{- $paginator = .Paginate .RegularPagesRecursive -}}
 {{- end -}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Template-only SEO and layout changes with no auth or data handling; alias pages no longer emit a canonical link in their standalone head.
> 
> **Overview**
> Introduces a default **`baseof.html`** shell (title block, `head.html`, optional Gatekeeper/Ezoic scripts, bootstrap init) and wires **`head/canonical`** so canonical URLs respect `relcanonical`, paginator page numbers, and `/page/N/` list URLs.
> 
> **Structured data** is refactored: inline `BlogPosting` JSON-LD in `head.html` moves to **`schema-blog-posting`**, reused for regular pages and **alias** redirect pages; **taxonomy/term** pages get new **`schema-collection-page`** (`CollectionPage` + breadcrumbs). **`head/title`** now paginates **term** listings the same way as taxonomy lists.
> 
> **Alias** layout drops its inline canonical tag and gains the shared blog-posting schema partial instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c530def92cdba4d4276fbef542c17616a2b6f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->