### PR TITLE
fix

### DIFF
--- a/layouts/partials/head/canonical.html
+++ b/layouts/partials/head/canonical.html
@@ -3,9 +3,9 @@
 <link rel="canonical" href="{{ . | relLangURL }}" itemprop="url" />
 {{ else }}
   {{- $canonical := .Permalink -}}
-  {{- with .Paginator -}}
-    {{- if gt .PageNumber 1 -}}
-      {{- $canonical = .URL | absLangURL -}}
+  {{- if .Paginator -}}
+    {{- if gt .Paginator.PageNumber 1 -}}
+      {{- $canonical = .Paginator.URL | absLangURL -}}
     {{- end -}}
   {{- else if strings.Contains .RelPermalink "/page/" -}}
     {{- $canonical = .RelPermalink | absLangURL -}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single partial change to canonical link output; no auth, data, or application logic.
> 
> **Overview**
> Fixes how **canonical** `<link>` URLs are built for **paginated list pages** in `layouts/partials/head/canonical.html`.
> 
> The template no longer uses `with .Paginator` (which rebinds `.` to the paginator). It uses `if .Paginator` and reads **`.Paginator.PageNumber`** and **`.Paginator.URL`** on the page context instead. Paginated pages after page 1 should get a canonical URL that matches the current list page (e.g. `/page/2/`), consistent with the existing `/page/` fallback on **`.RelPermalink`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29695c2029c8b43940d698d6adf96d9029a2262e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->