### PR TITLE
hh

### DIFF
--- a/layouts/partials/head/schema-collection-page.html
+++ b/layouts/partials/head/schema-collection-page.html
@@ -1,9 +1,9 @@
 {{- $page := .page -}}
 {{- $pageDesc := printf "%s - %s" $page.Title ($page.Site.Params.description | default "") | plainify | htmlUnescape -}}
 {{- $pageURL := $page.Permalink -}}
-{{- with $page.Paginator -}}
-  {{- if gt .PageNumber 1 -}}
-    {{- $pageURL = .URL | absLangURL -}}
+{{- if $page.Paginator -}}
+  {{- if gt $page.Paginator.PageNumber 1 -}}
+    {{- $pageURL = $page.Paginator.URL | absLangURL -}}
   {{- end -}}
 {{- else if strings.Contains $page.RelPermalink "/page/" -}}
   {{- $pageURL = $page.RelPermalink | absLangURL -}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small Hugo template change for JSON-LD on list pagination only; mirrors existing canonical URL logic with no auth or data impact.
> 
> **Overview**
> Updates **CollectionPage** JSON-LD in `schema-collection-page.html` so paginated list URLs match the page being viewed, using the same approach as `canonical.html`.
> 
> The partial no longer uses `with $page.Paginator` (which narrowed Hugo’s dot scope). It now checks `$page.Paginator` explicitly and sets `$pageURL` from `$page.Paginator.URL` when `PageNumber` is greater than 1, so structured data `url` / `@id` align with paginated list pages instead of always pointing at page 1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7abc7497895aae7bbc7eded8d86bcd6149a95694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->