### PR TITLE
ff

### DIFF
--- a/layouts/partials/head/canonical.html
+++ b/layouts/partials/head/canonical.html
@@ -3,11 +3,7 @@
 <link rel="canonical" href="{{ . | relLangURL }}" itemprop="url" />
 {{ else }}
   {{- $canonical := .Permalink -}}
-  {{- if .Paginator -}}
-    {{- if gt .Paginator.PageNumber 1 -}}
-      {{- $canonical = .Paginator.URL | absLangURL -}}
-    {{- end -}}
-  {{- else if strings.Contains .RelPermalink "/page/" -}}
+  {{- if strings.Contains .RelPermalink "/page/" -}}
     {{- $canonical = .RelPermalink | absLangURL -}}
   {{- end -}}
 <link rel="canonical" href="{{ $canonical }}" itemprop="url" />

--- a/layouts/partials/head/schema-collection-page.html
+++ b/layouts/partials/head/schema-collection-page.html
@@ -1,11 +1,7 @@
 {{- $page := .page -}}
 {{- $pageDesc := printf "%s - %s" $page.Title ($page.Site.Params.description | default "") | plainify | htmlUnescape -}}
 {{- $pageURL := $page.Permalink -}}
-{{- if $page.Paginator -}}
-  {{- if gt $page.Paginator.PageNumber 1 -}}
-    {{- $pageURL = $page.Paginator.URL | absLangURL -}}
-  {{- end -}}
-{{- else if strings.Contains $page.RelPermalink "/page/" -}}
+{{- if strings.Contains $page.RelPermalink "/page/" -}}
   {{- $pageURL = $page.RelPermalink | absLangURL -}}
 {{- end -}}
 {{- $website := dict "@type" "WebSite" "@id" (printf "%s#website" $page.Site.Home.Permalink) "name" $page.Site.Title "url" $page.Site.Home.Permalink -}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small Hugo template change affecting SEO metadata only; behavior should match paginated URLs already used elsewhere.
> 
> **Overview**
> **Canonical links** and **CollectionPage JSON-LD** no longer branch on Hugo’s `.Paginator` / page number. Both partials now set the paginated URL only when `RelPermalink` contains `/page/`, using `absLangURL` on that path—same idea as `head/meta/robots.html` for paginated home.
> 
> Page 1 of a list still uses `.Permalink`; explicit `relcanonical` in front matter is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b12dac718b2e5d614047531cd835033326609f9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->