### PR TITLE
fix

### DIFF
--- a/content/posts/2015/monitoring-screens.md
+++ b/content/posts/2015/monitoring-screens.md
@@ -24,7 +24,7 @@ aliases = [
     "/2015/03/25/monitoring-screens"
 ]
 +++
-We all know that it is important to monitor your servers and services, so you can spot issues before they become problems. I personally have spent a lot of time configuring [nagios](https://www.funkysi1701.com/2014/09/24/i-love-nagios/) to email me about issues and I have recently been configuring various different alerts in Azure.
+We all know that it is important to monitor your servers and services, so you can spot issues before they become problems. I personally have spent a lot of time configuring [nagios](https://www.funkysi1701.com/posts/2014/i-love-nagios/) to email me about issues and I have recently been configuring various different alerts in Azure.
 
 My old boss has this idea that I should have a big monitor screen displaying all the vital stats of my servers and services, I personally disagree with this idea and think that notifications on my phone and email alerts are sufficient. He will no doubt correct my thinking when he reads this, but I believe part of his thinking is to make the monitoring of your infrastructure move visible and make it obvious to anyone that walks past that you have your eye on everything.
 

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -46,7 +46,16 @@
   {{- with site.Params.social.twitter -}}
   <meta name="twitter:site" content="@{{ . }}">
   {{- end -}}
-  {{- partial "head/schema-blog-posting" (dict "page" .) -}}
+  {{- $aliasSchema := dict
+    "@context" "https://schema.org"
+    "@type" "BlogPosting"
+    "headline" $title
+    "description" $pageDesc
+    "url" .Permalink
+    "image" $image
+    "mainEntityOfPage" (dict "@type" "WebPage" "@id" .Permalink)
+  -}}
+  <script type="application/ld+json">{{- $aliasSchema | jsonify | safeJS -}}</script>
   <meta http-equiv="refresh" content="0; url={{ .Permalink }}">
 </head>
 <body>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -48,6 +48,6 @@
 <script type="application/ld+json">{{- $websiteJSON | safeJS -}}</script>
 {{- else if .IsPage -}}
 {{- partial "head/schema-blog-posting" (dict "page" .) -}}
-{{- else if or (eq .Kind "term") (eq .Kind "taxonomy") -}}
+{{- else if or (eq .Kind "term") (eq .Kind "taxonomy") (eq .Kind "section") -}}
 {{- partial "head/schema-collection-page" (dict "page" .) -}}
 {{- end -}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Template and one markdown link changes only; no auth, data, or runtime application logic.
> 
> **Overview**
> Updates a **2015 post** so the Nagios link points at the canonical `/posts/2014/i-love-nagios/` path instead of the old `/2014/09/24/...` URL.
> 
> **Alias redirect pages** (`layouts/alias.html`) now emit **inline `BlogPosting` JSON-LD** (title, description, URL, image, `mainEntityOfPage`) instead of the shared `schema-blog-posting` partial.
> 
> **Site head** (`layouts/partials/head.html`) also outputs **collection-page structured data** for Hugo **`section`** list pages, in addition to taxonomy and term pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03442763923a4399d28726e2de2958160f83ff73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->