### PR TITLE
fix

### DIFF
--- a/content/funky-si-the-next-generation.md
+++ b/content/funky-si-the-next-generation.md
@@ -26,7 +26,7 @@ On 19th August at 9.39 pm James David Martin Foster arrived weighing 9 lb 12.
 ![](/images/COogcqtXAAAzZ7A.jpg)
 ![](/images/COZF5PjWUAAhcan.jpg)
 
-My initial thoughts on fatherhood can be found [here](https://www.funkysi1701.com/2015/09/03/baby-magic-and-becoming-a-father/). More baby photos can also be found on my [instragram](https://www.instagram.com/funkysi1701/).
+My initial thoughts on fatherhood can be found [here](https://www.funkysi1701.com/posts/2015/baby-magic-and-becoming-a-father/). More baby photos can also be found on my [instragram](https://www.instagram.com/funkysi1701/).
 
 ![](/images/twitter.jpg)
 

--- a/content/posts/2015/50th-blog-post.md
+++ b/content/posts/2015/50th-blog-post.md
@@ -32,22 +32,22 @@ I have tried to blog at least every week and I have learnt a lot. I have talked 
 
 To celebrate here are some of my highlights.
 
-1) [User Groups and F#](https://www.funkysi1701.com/2015/05/30/user-groups-and-f/) By far my most popular blog post. I talk about my first visit to the Leeds Sharp group and an introduction to the F# language.
+1) [User Groups and F#](https://www.funkysi1701.com/posts/2015/user-groups-and-f/) By far my most popular blog post. I talk about my first visit to the Leeds Sharp group and an introduction to the F# language.
 
-2) [Monitoring Screens](https://www.funkysi1701.com/2015/03/25/monitoring-screens/) I talk about creating a big screen of vital monitoring information.
+2) [Monitoring Screens](https://www.funkysi1701.com/posts/2015/monitoring-screens/) I talk about creating a big screen of vital monitoring information.
 
-3) [Ten Forward Episode #135](https://www.funkysi1701.com/2015/02/13/ten-forward-episode-135-anti-firbob-is-back-or-simons-desert-island-trek/) – Simon’s Desert Island Trek My appearance on the Ten Forward Podcast
+3) [Ten Forward Episode #135](https://www.funkysi1701.com/posts/2015/ten-forward-episode-135-anti-firbob-is-back-or-simons-desert-island-trek/) – Simon’s Desert Island Trek My appearance on the Ten Forward Podcast
 
-4) [Building something with a Raspberry Pi](https://www.funkysi1701.com/2015/04/05/building-something-with-a-raspberry-pi/) I blog about getting a Raspberry Pi to play around with
+4) [Building something with a Raspberry Pi](https://www.funkysi1701.com/posts/2015/building-something-with-a-raspberry-pi/) I blog about getting a Raspberry Pi to play around with
 
 5) [Improving your Blog](https://www.funkysi1701.com/posts/2015/02/23/improving-your-blog/) John Sonmez tries to help my blog improve
 
-6) [Javascript progress](https://www.funkysi1701.com/2015/01/16/javascript-progress/) About learning javascript
+6) [Javascript progress](https://www.funkysi1701.com/posts/2015/javascript-progress/) About learning javascript
 
-7) [The Raspberry Pi Adventure Starts](https://www.funkysi1701.com/2015/04/11/the-raspberry-pi-adventure-starts/) I get a Raspberry Pi and start building something with it
+7) [The Raspberry Pi Adventure Starts](https://www.funkysi1701.com/posts/2015/the-raspberry-pi-adventure-starts/) I get a Raspberry Pi and start building something with it
 
-8) [Weakest Database Design](https://www.funkysi1701.com/2015/04/21/weakest-database-design/) I talk about database design
+8) [Weakest Database Design](https://www.funkysi1701.com/posts/2015/weakest-database-design/) I talk about database design
 
-9) [Trying Windows 10](https://www.funkysi1701.com/2015/05/17/trying-windows-10/) I talk about my experience with the latest windows operating system
+9) [Trying Windows 10](https://www.funkysi1701.com/posts/2015/trying-windows-10/) I talk about my experience with the latest windows operating system
 
-10) [Laziness](https://www.funkysi1701.com/2015/02/04/laziness/) I talk about the extreme ways IT Professionals go to be more lazy
+10) [Laziness](https://www.funkysi1701.com/posts/2015/laziness/) I talk about the extreme ways IT Professionals go to be more lazy

--- a/content/posts/2015/backing-up-sql-databases-to-azure.md
+++ b/content/posts/2015/backing-up-sql-databases-to-azure.md
@@ -30,7 +30,7 @@ Unfortunately I am running SQL Server 2005 so this process will not work for me 
 
 The next thing I tried was [Microsoft SQL Server Backup to Microsoft Azure Tool](https://www.microsoft.com/en-us/download/details.aspx?id=40740&WT.mc_id=Blog_SQL_Announce_DI). Unfortunately I did not get this tool to work correctly on my setup. However it sounds like a flexible tool that allows compression and encryption of your backup files. This tool redirects your backup files to your Azure Storage so even if I had got it to work correctly it would not have been an ideal solution as I want local copies of my backup files as well.
 
-After this I started to look at powershell again. Following on from my recent success with [powershell](https://www.funkysi1701.com/2015/10/01/copying-settings-to-an-azure-website/) I know how to connect to my Azure account so all I needed to script was copying a file from my server to Azure.
+After this I started to look at powershell again. Following on from my recent success with [powershell](https://www.funkysi1701.com/posts/2015/copying-settings-to-an-azure-website/) I know how to connect to my Azure account so all I needed to script was copying a file from my server to Azure.
 
 ```
 Get-ChildItem *.bak -File -Recurse | Set-AzureStorageBlobContent -Container $DestContainer -Force

--- a/content/posts/2015/i-might-actually-like-sql-server.md
+++ b/content/posts/2015/i-might-actually-like-sql-server.md
@@ -44,7 +44,7 @@ It’s not like I woke up this morning with SQL Server knowledge. For many years
 
 For every single one of the steps above I googled and looked up the SQL syntax (every time I write an insert or update statement I look up the syntax, one day it will stick in my brain!) I think the main reason is once you have used SQL for a while you get to see how it works and can split it down into small steps.
 
-As I [blogged](https://www.funkysi1701.com/2015/04/21/weakest-database-design/) the other day I am currently working on improving a bad database and today I wanted to test the deployment process. All my changes are in a SSDT project so I took a backup of my database and tried to publish.
+As I [blogged](https://www.funkysi1701.com/posts/2015/weakest-database-design/) the other day I am currently working on improving a bad database and today I wanted to test the deployment process. All my changes are in a SSDT project so I took a backup of my database and tried to publish.
 
 Error! Your changes will result in data loss, no surprises there as I was expecting that error. The main culprit for this was a trigger I wrote but I didn’t find that out until the end of the day.
 

--- a/content/posts/2015/look-back-2015.md
+++ b/content/posts/2015/look-back-2015.md
@@ -29,59 +29,59 @@ Wow! What an amazing year 2015 has been and with 2015 about to end I thought it 
 
 **January**
 
-I started the year with a declaration that 2015 would be my year of code. Well I have had a few breaks from programming but I have learnt loads this year. I have flitted a bit concentrating on different areas of programming but I think that has broadened my knowledge. I consider myself to be a [programmer now](https://www.funkysi1701.com/2015/06/03/im-a-developer-now/), which I didn’t at the start of 2015.
+I started the year with a declaration that 2015 would be my year of code. Well I have had a few breaks from programming but I have learnt loads this year. I have flitted a bit concentrating on different areas of programming but I think that has broadened my knowledge. I consider myself to be a [programmer now](https://www.funkysi1701.com/posts/2015/im-a-developer-now/), which I didn’t at the start of 2015.
 
 **February**
 
-A first for 2015 was appearing on a [podcast](https://www.funkysi1701.com/2015/01/27/podcasts/). The Trekmate podcast [Ten Forward](https://www.funkysi1701.com/2015/02/13/ten-forward-episode-135-anti-firbob-is-back-or-simons-desert-island-trek/) were the lucky ones that got to experience my first attempt at talking to the world. This continued throughout the year with appearances on [Upper Pylon 2](https://www.funkysi1701.com/2015/07/30/upper-pylon-2-1-x-09-the-passenger/), [The Battle Bridge](https://www.funkysi1701.com/2015/10/08/the-hunted-tng-s3-e11-the-battle-bridge/) and even the [Sci-Fi Waffle](https://www.funkysi1701.com/2015/11/12/star-trek-is-back-in-2017/) podcast.
+A first for 2015 was appearing on a [podcast](https://www.funkysi1701.com/posts/2015/podcasts/). The Trekmate podcast [Ten Forward](https://www.funkysi1701.com/posts/2015/ten-forward-episode-135-anti-firbob-is-back-or-simons-desert-island-trek/) were the lucky ones that got to experience my first attempt at talking to the world. This continued throughout the year with appearances on [Upper Pylon 2](https://www.funkysi1701.com/posts/2015/upper-pylon-2-1-x-09-the-passenger/), [The Battle Bridge](https://www.funkysi1701.com/posts/2015/the-hunted-tng-s3-e11-the-battle-bridge/) and even the [Sci-Fi Waffle](https://www.funkysi1701.com/posts/2015/star-trek-is-back-in-2017/) podcast.
 
-It was a sad time for Trekkies at the end of February when [Leonard Nimoy](https://www.funkysi1701.com/2015/02/28/hes-really-not-dead-as-long-as-we-remember-him/) passed away.
+It was a sad time for Trekkies at the end of February when [Leonard Nimoy](https://www.funkysi1701.com/posts/2015/hes-really-not-dead-as-long-as-we-remember-him/) passed away.
 
 **March**
 
-In March I talked about my recent efforts with [Azure Traffic Manager](https://www.funkysi1701.com/2015/03/12/azure-traffic-manager/) to help prevent downtime. I also spent a lot of time improving [databases](https://www.funkysi1701.com/2015/03/05/database-deployment/) which led me to consider ways to deploy it better.
+In March I talked about my recent efforts with [Azure Traffic Manager](https://www.funkysi1701.com/posts/2015/azure-traffic-manager/) to help prevent downtime. I also spent a lot of time improving [databases](https://www.funkysi1701.com/posts/2015/database-deployment/) which led me to consider ways to deploy it better.
 
-Also in March I attended an IT networking event called [ITBoss](https://www.funkysi1701.com/2015/03/22/networking-event/). Free food and drinks and a discussion with fellow IT Managers.
+Also in March I attended an IT networking event called [ITBoss](https://www.funkysi1701.com/posts/2015/networking-event/). Free food and drinks and a discussion with fellow IT Managers.
 
 **April**
 
 April was a bit of a mixed bag. I celebrated my second wedding anniversary but I also said goodbye to my car due to financial reasons.
 
-I played about with a [Raspberry Pi](https://www.funkysi1701.com/2015/04/11/the-raspberry-pi-adventure-starts/), mostly with the [camera](https://www.funkysi1701.com/2015/04/15/security-camera-with-raspberry-pi-camera/). I really must make some time to play with it more.
+I played about with a [Raspberry Pi](https://www.funkysi1701.com/posts/2015/the-raspberry-pi-adventure-starts/), mostly with the [camera](https://www.funkysi1701.com/posts/2015/security-camera-with-raspberry-pi-camera/). I really must make some time to play with it more.
 
 **May**
 
-In May I went to a C# User Group called Leeds Sharp, was great fun and I really need to make more time and go back in 2016. It did result in one of my [most popular blog posts](https://www.funkysi1701.com/2015/05/30/user-groups-and-f/).
+In May I went to a C# User Group called Leeds Sharp, was great fun and I really need to make more time and go back in 2016. It did result in one of my [most popular blog posts](https://www.funkysi1701.com/posts/2015/user-groups-and-f/).
 
-Usually developers don’t enjoy finding bugs in their software but I had great fun when I realised I had a [Stack Overflow](https://www.funkysi1701.com/2015/05/22/overflow/) in one of my databases, it was easy to fix once I worked out what was going on.
+Usually developers don’t enjoy finding bugs in their software but I had great fun when I realised I had a [Stack Overflow](https://www.funkysi1701.com/posts/2015/overflow/) in one of my databases, it was easy to fix once I worked out what was going on.
 
 In May the UK went to the polls as we had another General Election.
 
 **June**
 
-In June I celebrated my [50th Blog Post](https://www.funkysi1701.com/2015/06/17/50th-blog-post/). Amazing to think I had already written 50 Blog posts, even more now!
+In June I celebrated my [50th Blog Post](https://www.funkysi1701.com/posts/2015/50th-blog-post/). Amazing to think I had already written 50 Blog posts, even more now!
 
-Leeds Sharp had a coding challenge, to solve [Sodoku](https://www.funkysi1701.com/2015/06/26/sudoku-challenge/) puzzle programatically. Didn’t get it finished but made a good stab at it.
+Leeds Sharp had a coding challenge, to solve [Sodoku](https://www.funkysi1701.com/posts/2015/sudoku-challenge/) puzzle programatically. Didn’t get it finished but made a good stab at it.
 
 **July**
 
 In July it was SysAdmin Day and I celebrated with my staff the amazing work we do keeping everything working.
 
-Microsoft launched [Windows 10](https://www.funkysi1701.com/2015/07/11/how-to-upgrade-to-windows-10/) in July, the latest operating system is being offered for free for a year.
+Microsoft launched [Windows 10](https://www.funkysi1701.com/posts/2015/how-to-upgrade-to-windows-10/) in July, the latest operating system is being offered for free for a year.
 
 **August**
 
-In August everything changed as my son [James](https://www.funkysi1701.com/2015/09/03/baby-magic-and-becoming-a-father/) was born. I took time out from blogging and work during this time to spend with James.
+In August everything changed as my son [James](https://www.funkysi1701.com/posts/2015/baby-magic-and-becoming-a-father/) was born. I took time out from blogging and work during this time to spend with James.
 
-Before James was born I stepped down from my involvement with the [technical team](https://www.funkysi1701.com/2015/08/03/volunteering-for-a-technical-team/) at St Michael le Belfrey.
+Before James was born I stepped down from my involvement with the [technical team](https://www.funkysi1701.com/posts/2015/volunteering-for-a-technical-team/) at St Michael le Belfrey.
 
 **September**
 
-In september it was back to work, where I started planning how to add [internet connections](https://www.funkysi1701.com/2015/09/24/adding-internet-connection-resiliency/) to reduce the chance of outages.
+In september it was back to work, where I started planning how to add [internet connections](https://www.funkysi1701.com/posts/2015/adding-internet-connection-resiliency/) to reduce the chance of outages.
 
 **October**
 
-In October I took James to a [dads group](https://www.funkysi1701.com/2015/10/22/james-goes-on-an-adventure-with-daddy/). This was the first time Dad spent time with James without Mummy and it was awesome.
+In October I took James to a [dads group](https://www.funkysi1701.com/posts/2015/james-goes-on-an-adventure-with-daddy/). This was the first time Dad spent time with James without Mummy and it was awesome.
 
 I also celebrated my first birthday after becoming a father, was great to have a card from James. James also got the chance to spend time with my family in Nottingham.
 
@@ -89,15 +89,15 @@ I also celebrated my first birthday after becoming a father, was great to have a
 
 In November the countdown to Christmas began with James appearing in his first Nativity as Jesus and dressed up as an Elf at a Christingle service.
 
-Exciting Star Trek news was announced this month, a new [TV series](https://www.funkysi1701.com/2015/11/12/star-trek-is-back-in-2017/) is to be aired in January 2017. No other details yet but very exciting.
+Exciting Star Trek news was announced this month, a new [TV series](https://www.funkysi1701.com/posts/2015/star-trek-is-back-in-2017/) is to be aired in January 2017. No other details yet but very exciting.
 
 **December**
 
-December is all about [Christmas](https://www.funkysi1701.com/2015/12/24/christmas-2015-fosters/) and we had a great Christmas time as a family.
+December is all about [Christmas](https://www.funkysi1701.com/posts/2015/christmas-2015-fosters/) and we had a great Christmas time as a family.
 
 Sadly York was hit by Floods just after Christmas, luckily my family was not affected but many others have been. Hopefully by the time you read this the cleanup will be well underway.
 
-Before Christmas I spent my time counting down the days with the [Advent of Code](https://www.funkysi1701.com/2015/12/17/christmas-count-code/)
+Before Christmas I spent my time counting down the days with the [Advent of Code](https://www.funkysi1701.com/posts/2015/christmas-count-code/)
 
 **What will 2016 bring?**
 

--- a/content/posts/2016/amazon-web-services.md
+++ b/content/posts/2016/amazon-web-services.md
@@ -48,4 +48,4 @@ Azure has a host of command lines available via powershell. AWS has a similar co
 
 AWS Toolkit for Visual Studio is an extension that allows for the publishing of websites to AWS. (Just like you can publish to Azure)
 
-As I learn more about AWS I will continue to blog about it. [Amazon Web Services Pt 2](https://www.funkysi1701.com/2016/08/04/amazon-web-services-pt-2/)
+As I learn more about AWS I will continue to blog about it. [Amazon Web Services Pt 2](https://www.funkysi1701.com/posts/2016/amazon-web-services-pt-2/)

--- a/content/posts/2016/i-m-100-blog-posts-old.md
+++ b/content/posts/2016/i-m-100-blog-posts-old.md
@@ -41,4 +41,4 @@ Hopefully a refreshed look in the next few months. Hopefully regular posts. If t
 
 **What is my favourite post?**
 
-Maybe [User Groups and F#](https://www.funkysi1701.com/2015/05/30/user-groups-and-f/) which proved very popular and got me to start going to user groups something I still enjoy today. I also like [Coding Myself Into A Corner](https://www.funkysi1701.com/2016/02/25/coding-myself-into-a-corner/) which got me to start thinking more if I was giving myself future problems. But there are many others I like such as [James and Becoming a father](https://www.funkysi1701.com/2015/09/03/baby-magic-and-becoming-a-father/)
+Maybe [User Groups and F#](https://www.funkysi1701.com/posts/2015/user-groups-and-f/) which proved very popular and got me to start going to user groups something I still enjoy today. I also like [Coding Myself Into A Corner](https://www.funkysi1701.com/posts/2016/coding-myself-into-a-corner/) which got me to start thinking more if I was giving myself future problems. But there are many others I like such as [James and Becoming a father](https://www.funkysi1701.com/posts/2015/baby-magic-and-becoming-a-father/)

--- a/content/posts/2016/revisiting-teamcity.md
+++ b/content/posts/2016/revisiting-teamcity.md
@@ -23,7 +23,7 @@ aliases = [
     "/2016/03/24/revisiting-teamcity"
 ]
 +++
-Last year I blogged about [Team City](https://www.funkysi1701.com/2015/04/01/teamcity/), well I have been looking at it again recently. In that time they have even changed their logo!
+Last year I blogged about [Team City](https://www.funkysi1701.com/posts/2015/teamcity/), well I have been looking at it again recently. In that time they have even changed their logo!
 
 Lets start with thinking about what I want my Continuous Integration server to do.
 

--- a/content/posts/2016/top-50-star-trek-episodes.md
+++ b/content/posts/2016/top-50-star-trek-episodes.md
@@ -39,7 +39,7 @@ The original Star Trek series first aired on September 8th 1966. It lasted only 
 2. The Devil in the Dark
 3. Balance of Terror
 4. The Trouble with Tribbles
-5. [Arena](https://www.funkysi1701.com/2016/01/21/star-trek-episode-review-arena/)
+5. [Arena](https://www.funkysi1701.com/posts/2016/star-trek-episode-review-arena/)
 6. This Side of Paradise
 7. Amok Time
 8. Space Seed
@@ -52,7 +52,7 @@ The original Star Trek series first aired on September 8th 1966. It lasted only 
 
 The first spin-off series set 100 years after Kirk featured a new Enterprise continuing to explore space. This series aired between 1987 and 1994 for 178 episodes.
 
-1. [Best of Both Worlds](https://www.funkysi1701.com/2016/02/18/star-trek-episode-review-the-best-of-both-worlds/)
+1. [Best of Both Worlds](https://www.funkysi1701.com/posts/2016/star-trek-episode-review-the-best-of-both-worlds/)
 2. Yesterdays Enterprise
 3. The Offspring
 4. The Measure of a Man

--- a/content/posts/2017/fiddler-and-apis.md
+++ b/content/posts/2017/fiddler-and-apis.md
@@ -24,7 +24,7 @@ aliases = [
 ]
 +++
 
-A while ago I blogged about [promoting](https://www.funkysi1701.com/2017/04/17/automation-promotion/) my blog with Buffer. At the time I made use of the nuget package [BufferAPI](https://www.nuget.org/packages/BufferAPI/) but lets look at some improvements I can make.
+A while ago I blogged about [promoting](https://www.funkysi1701.com/posts/2017/automation-promotion/) my blog with Buffer. At the time I made use of the nuget package [BufferAPI](https://www.nuget.org/packages/BufferAPI/) but lets look at some improvements I can make.
 
 The BufferAPI package worked great from my console app, but when I tried to use it from a Controller in an MVC app I never got it to work. Lets look at the API docs and see if I can rewrite it.
 

--- a/content/posts/2017/how-do-i-add-power-bi-data-to-a-webpage.md
+++ b/content/posts/2017/how-do-i-add-power-bi-data-to-a-webpage.md
@@ -24,7 +24,7 @@ aliases = [
 ]
 +++
 
-Last week I talked about [Power BI](https://www.funkysi1701.com/2017/06/05/businessintelligence/), what it is and some of the different services you can use with it. This week lets add some of that data to a simple web page.
+Last week I talked about [Power BI](https://www.funkysi1701.com/posts/2017/businessintelligence/), what it is and some of the different services you can use with it. This week lets add some of that data to a simple web page.
 
 For this example I am going to add the google analytics data from this website to this page.
 

--- a/content/posts/2017/solid-programming-terms.md
+++ b/content/posts/2017/solid-programming-terms.md
@@ -27,7 +27,7 @@ This week I have been looking at improving my understanding of a few programming
 
 ### MVC
 
-I have previously blogged about [MVC](https://www.funkysi1701.com/2016/03/17/model-view-controller-mvc/), but my understanding was not 100% correct so I will refine this here.
+I have previously blogged about [MVC](https://www.funkysi1701.com/posts/2016/model-view-controller-mvc/), but my understanding was not 100% correct so I will refine this here.
 
 **Model** – Now this is where my understanding was not quite correct. I thought the model was the actual source data, eg an XML file, SQL database etc. The model is the business logic so this is a processed version of the source data. MVC does not care where data is stored it can be flat files, SQL, XML or anything really.
 

--- a/content/posts/2018/flexible-architecture.md
+++ b/content/posts/2018/flexible-architecture.md
@@ -25,7 +25,7 @@ aliases = [
 +++
 I have blogged a few times about [interfaces](https://www.funkysi1701.com/posts/2017/interfaces/), and how useful they are for producing good quality maintainable code. Let’s look at a problem and the solution I came up with which I am quite proud of.
 
-As previously mentioned I am in the process of moving [images](https://www.funkysi1701.com/2018/01/22/moving-blobs-cloud-suppliers/) from AWS to Azure blob storage. Now that the actual files themselves have been moved I need to change the code that references them.
+As previously mentioned I am in the process of moving [images](https://www.funkysi1701.com/posts/2018/moving-blobs-cloud-suppliers/) from AWS to Azure blob storage. Now that the actual files themselves have been moved I need to change the code that references them.
 
 Now I could find all the code that uses the AWS API and replace it with the Azure API but I am not very good at predicting the future, we may stay on Azure for a while, we may move to AWS or Google Cloud, or we may want to go back to files sitting on a server.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Markdown-only URL updates with no application or auth changes; broken links are possible only if target permalinks do not match the new paths.
> 
> **Overview**
> Updates **internal markdown links** across a batch of Hugo `content` pages so they point at the current permalink shape (`https://www.funkysi1701.com/posts/{year}/{slug}/`) instead of legacy **date-in-path** URLs (`/2015/MM/DD/...`).
> 
> The bulk of the edits are in **`look-back-2015.md`** and **`50th-blog-post.md`**, which retarget many cross-post references; smaller posts (2016–2018) and **`funky-si-the-next-generation.md`** get the same treatment for a handful of links each. One link in the 50th-post list still uses the older nested path (`/posts/2015/02/23/improving-your-blog/`), so this pass is **not fully uniform**.
> 
> No build config, redirects, or front matter aliases change here—only link targets in prose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 767fd87f228a80104461e8dcb0e857ee97a4df37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->