### PR TITLE
more fixes

### DIFF
--- a/content/posts/2015/50th-blog-post.md
+++ b/content/posts/2015/50th-blog-post.md
@@ -40,7 +40,7 @@ To celebrate here are some of my highlights.
 
 4) [Building something with a Raspberry Pi](https://www.funkysi1701.com/posts/2015/building-something-with-a-raspberry-pi/) I blog about getting a Raspberry Pi to play around with
 
-5) [Improving your Blog](https://www.funkysi1701.com/posts/2015/02/23/improving-your-blog/) John Sonmez tries to help my blog improve
+5) [Improving your Blog](https://www.funkysi1701.com/posts/2015/improving-your-blog/) John Sonmez tries to help my blog improve
 
 6) [Javascript progress](https://www.funkysi1701.com/posts/2015/javascript-progress/) About learning javascript
 

--- a/content/posts/2015/runaway-sql-log-growth.md
+++ b/content/posts/2015/runaway-sql-log-growth.md
@@ -23,7 +23,7 @@ aliases = [
 ]
 +++
 
-Today is my day off, but I wake up and have a quick look at [nagios](https://www.funkysi1701.com/posts/i-love-nagios/) to see if there is anything I need to worry about. Yes there is, SQL Server has run out of disk space on its data disk.
+Today is my day off, but I wake up and have a quick look at [nagios](https://www.funkysi1701.com/posts/2014/i-love-nagios/) to see if there is anything I need to worry about. Yes there is, SQL Server has run out of disk space on its data disk.
 
 I race downstairs and VPN onto the server to find out what has happened. One of my monitoring databases has had runaway log growth and is over 80Gb is size.
 

--- a/content/posts/2017/azure-functions.md
+++ b/content/posts/2017/azure-functions.md
@@ -23,7 +23,7 @@ aliases = [
     "/2017/09/12/azure-functions"
 ]
 +++
-I recently blogged about using [Azure Web Jobs](https://www.funkysi1701.com/posts/using-azure-webjobs-to-automate-stuff), Azure Function is another way of doing the same thing, lets look at how they work.
+I recently blogged about using [Azure Web Jobs](https://www.funkysi1701.com/posts/2017/using-azure-webjobs-to-automate-stuff/), Azure Function is another way of doing the same thing, lets look at how they work.
 
 (Sorry its been a while since I blogged but I suspect an erratic schedule will continue for the next few months.)
 

--- a/content/posts/2017/interfaces-are-cool.md
+++ b/content/posts/2017/interfaces-are-cool.md
@@ -24,7 +24,7 @@ aliases = [
     "/posts/2017/interfaces-are-cool"
 ]
 +++
-A while back I [blogged](https://www.funkysi1701.com/posts/interfaces/) about learning about interfaces as I didn’t really understand the value of them. I do now.
+A while back I [blogged](https://www.funkysi1701.com/posts/2017/interfaces/) about learning about interfaces as I didn’t really understand the value of them. I do now.
 
 I created an application that used interfaces so I could learn how it worked. I created a Logger Interface and created multiple classes that implemented that interface so I could swap out the different implementations easily. I created a SQL Logger and a File Logger and my code could be written and be completely unaware of which implementation it was using.
 

--- a/content/posts/2017/looking-back-at-2017.md
+++ b/content/posts/2017/looking-back-at-2017.md
@@ -38,15 +38,15 @@ In September the latest Star Trek TV series Discovery arrived on Netflix. I have
 
 3) Office move
 
-In May I helped my employer move to brand new [offices](https://www.funkysi1701.com/office-move). This was a lot of hard work, but everything went as planned and our new home is great.
+In May I helped my employer move to brand new [offices](https://www.funkysi1701.com/posts/2017/office-move/). This was a lot of hard work, but everything went as planned and our new home is great.
 
 4) Side projects ![Google Play](/images/2017/googleplay.jpg)
 
-I blogged in February about having a side project but it wasn’t until later in the year that this solidified into what I am working on now. It started as a way to understand [interfaces](https://www.funkysi1701.com/interfaces)this then led to learning Xamarin and creating an android app to help promote this blog. Troy Hunt expanded his HIBP API to include passwords that have been in data breaches, I then started working on pwned passwords which is a simple android frontend for this.
+I blogged in February about having a side project but it wasn’t until later in the year that this solidified into what I am working on now. It started as a way to understand [interfaces](https://www.funkysi1701.com/posts/2017/interfaces/)this then led to learning Xamarin and creating an android app to help promote this blog. Troy Hunt expanded his HIBP API to include passwords that have been in data breaches, I then started working on pwned passwords which is a simple android frontend for this.
 
 5) Learning R
 
-In Feb I also experimented with a new programming language [R](https://www.funkysi1701.com/learning-r). It started with a problem about converting exchange rates and ended with a SQL stored procedure that executed some R code, I still want to learn lots more but it was a good example of the sorts of thing you can build with R.
+In Feb I also experimented with a new programming language [R](https://www.funkysi1701.com/posts/2017/learning-r/). It started with a problem about converting exchange rates and ended with a SQL stored procedure that executed some R code, I still want to learn lots more but it was a good example of the sorts of thing you can build with R.
 
 6) DNS programmatically
 

--- a/content/posts/2017/pwned-pass-available-from-the-play-store.md
+++ b/content/posts/2017/pwned-pass-available-from-the-play-store.md
@@ -39,7 +39,7 @@ My app simply generates a SHA1 hash of anything that is typed in and then passes
 
 It should be noted that:  **Do not send any password you actively use to a third-party service – even this one!** I don’t log anything that you type into my app and all I am then doing is passing a SHA1 hash over SSL to HIBP. However you shouldn’t trust my word alone.
 
-The app itself is written in Visual Studio with Xamarin Forms in a similar fashion to the app I talked about [last week](https://www.funkysi1701.com/posts/android-app-development-and-the-visual-studio-mobile-centre).
+The app itself is written in Visual Studio with Xamarin Forms in a similar fashion to the app I talked about [last week](https://www.funkysi1701.com/posts/2017/android-app-development-and-the-visual-studio-mobile-centre/).
 
 As I am using Xamarin Forms there is the potential that I may develop iPhone or UWP versions of this code in the future. With that in mind I have made use of interfaces for the android specific parts of the code.
 

--- a/content/posts/2017/star-trek-is-back-with-discovery.md
+++ b/content/posts/2017/star-trek-is-back-with-discovery.md
@@ -25,7 +25,7 @@ aliases = [
 ]
 +++
 
-In [November 2015](https://www.funkysi1701.com/posts/star-trek-is-back-in-2017) it was announced that a new Star Trek series was going to be launched. It has been a long wait with multiple delays but Star Trek Discovery is finally here.
+In [November 2015](https://www.funkysi1701.com/posts/2015/star-trek-is-back-in-2017/) it was announced that a new Star Trek series was going to be launched. It has been a long wait with multiple delays but Star Trek Discovery is finally here.
 
 Star Trek Discovery launches in the US on 24th September and in the UK on 25th September.
 

--- a/content/posts/2018/dns-for-developers.md
+++ b/content/posts/2018/dns-for-developers.md
@@ -77,7 +77,7 @@ Like A record but for ipv6
 
 ### What next?
 
-Want to put some different DNS records into practise? Buy a domain name and publish some content to it. Check out my previous post about [programmatically adding records](https://www.funkysi1701.com/creating-dns-records-programmatically). Want an SSL certificate? Get a wildcard one and then you can apply it to any subdomain you add to your domain.
+Want to put some different DNS records into practise? Buy a domain name and publish some content to it. Check out my previous post about [programmatically adding records](https://www.funkysi1701.com/posts/2017/creating-dns-records-programmatically/). Want an SSL certificate? Get a wildcard one and then you can apply it to any subdomain you add to your domain.
 
 If you have a new website you want to publish consider which of the following is better:
 

--- a/content/posts/2019/technology-i-want-to-learn-more-about.md
+++ b/content/posts/2019/technology-i-want-to-learn-more-about.md
@@ -24,7 +24,7 @@ aliases = [
 ]
 +++
 
-While at [Microsoft Ignite](https://www.funkysi1701.com/2019/02/26/microsoft-ignite-the-tour-london) I heard about a lot of cool tech that I want to know more about. The best way to learn something is use it to solve a problem.
+While at [Microsoft Ignite](https://www.funkysi1701.com/posts/2019/microsoft-ignite-the-tour-london) I heard about a lot of cool tech that I want to know more about. The best way to learn something is use it to solve a problem.
 
 So what can I build that is both useful and will let me play with some new tech?
 

--- a/specs/funkysi1701-test-plan.md
+++ b/specs/funkysi1701-test-plan.md
@@ -254,7 +254,7 @@ Funkysi1701.com is a personal technical blog and portfolio website for Simon Fos
 **File:** `tests/blog-posts-content/blog-comments.spec.ts`
 
 **Steps:**
-  1. Navigate to a blog post (e.g., https://www.funkysi1701.com/posts/2026/01/31/ndc-london-2026)
+  1. Navigate to a blog post (e.g., https://www.funkysi1701.com/posts/2026/ndc-london-2026)
   2. Scroll to the bottom of the post
   3. Check for Giscus comment section
   4. Verify comment section loads
@@ -862,7 +862,7 @@ Funkysi1701.com is a personal technical blog and portfolio website for Simon Fos
 **File:** `tests/edge-cases/deep-link-access.spec.ts`
 
 **Steps:**
-  1. Directly navigate to a specific blog post URL (for example, https://www.funkysi1701.com/posts/2025/01/31/some-post – this is a placeholder; replace it with an actual existing post URL such as the NDC London 2026 post)
+  1. Directly navigate to a specific blog post URL (for example, https://www.funkysi1701.com/posts/2025/some-post – this is a placeholder; replace it with an actual existing post URL such as the NDC London 2026 post)
   2. Verify page loads without errors
   3. Directly navigate to a tag page (e.g., /tags/azure/)
   4. Verify tag page loads correctly


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Markdown-only link and test-doc URL updates; no application or routing logic changes.
> 
> **Overview**
> This PR **corrects internal cross-links** in several Hugo blog posts so they match the site’s **`/posts/{year}/{slug}/`** permalink style instead of legacy paths (date segments, missing year folders, or bare `/posts/...` URLs).
> 
> **Content changes** span posts from **2015–2019** (e.g. Nagios, Azure Web Jobs, interfaces, office move, Ignite, DNS). One **2015** highlight link drops the old `02/23` date segment in favor of the slug-only path.
> 
> **Test documentation** in `specs/funkysi1701-test-plan.md` is updated so example deep-link URLs for blog posts use the same **`/posts/2026/ndc-london-2026`** pattern (no `01/31` in the path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9896103309a4fd85f851badbf029e3718588837e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->