### PR TITLE
more

### DIFF
--- a/content/posts/2015/top-25-star-trek-characters.md
+++ b/content/posts/2015/top-25-star-trek-characters.md
@@ -83,9 +83,9 @@ I have just listened to a [podcast](https://www.trekmate.org.uk/ten-forward-epis
 
 If you enjoyed this character ranking, check out these other Star Trek articles:
 
-- [Top 50 Star Trek Episodes](/posts/2016/01/07/top-50-star-trek-episodes) - My ranking of the greatest episodes across all series
-- [A Comparison of All Good Things and Star Trek Picard](/posts/2021/12/15/a-comparison-of-all-good-things-and-star-trek-picard) - Examining how Picard's future was predicted
-- [Star Trek Episode Review: The Best of Both Worlds](/posts/2016/02/18/star-trek-episode-review-the-best-of-both-worlds) - A deep dive into the iconic Borg episode featuring Picard
+- [Top 50 Star Trek Episodes](/posts/2016/top-50-star-trek-episodes/) - My ranking of the greatest episodes across all series
+- [A Comparison of All Good Things and Star Trek Picard](/posts/2021/a-comparison-of-all-good-things-and-star-trek-picard/) - Examining how Picard's future was predicted
+- [Star Trek Episode Review: The Best of Both Worlds](/posts/2016/star-trek-episode-review-the-best-of-both-worlds/) - A deep dive into the iconic Borg episode featuring Picard
 - [Picard Season 3](/posts/2023/picard-season-three) - My thoughts on the final season of Star Trek Picard
 - [TrekRanks #174](/posts/2024/trekranks) - My appearance on the TrekRanks podcast
 

--- a/content/posts/2018/tips-for-developing-yourself.md
+++ b/content/posts/2018/tips-for-developing-yourself.md
@@ -44,7 +44,7 @@ Start building a side project, it doesn’t matter what it is but start building
 
 ##### Use your spare time
 
-During the day there are moments you can reclaim for learning stuff. There are lots of [podcast](https://www.funkysi1701.com/podcasts) which discuss useful development topics, listen to these while driving to work. Subscribe to [pluralsight](https://www.funkysi1701.com/posts/pluralsight) and listen to this while washing up. Don’t get too concerned with learning everything, however think how much more you are learning than not listening at all.
+During the day there are moments you can reclaim for learning stuff. There are lots of [podcast](https://www.funkysi1701.com/podcasts) which discuss useful development topics, listen to these while driving to work. Subscribe to [pluralsight](https://www.funkysi1701.com/posts/2018/pluralsight/) and listen to this while washing up. Don’t get too concerned with learning everything, however think how much more you are learning than not listening at all.
 
 ##### I’m not ready!
 

--- a/content/posts/2020/testing-for-expiring-ssl-certificates.md
+++ b/content/posts/2020/testing-for-expiring-ssl-certificates.md
@@ -23,7 +23,7 @@ aliases = [
     "/2020/03/03/testing-for-expiring-ssl-certificates"
 ]
 +++
-Let's Encrypt is amazing, you can easily add SSL certificates to any website and automate the renewal process. I have talked [before](https://www.funkysi1701.com/posts/let-s-encrypt-is-awesome-3f5j/) about how impressive it is.
+Let's Encrypt is amazing, you can easily add SSL certificates to any website and automate the renewal process. I have talked [before](https://www.funkysi1701.com/posts/2018/let-s-encrypt-is-awesome-3f5j/) about how impressive it is.
 
 Once you start adding SSL certificates to your production sites however you may want to check when they expire so you don't get caught out. You can always open your site in your favourite browser and view the certificate information and expiry date.
 

--- a/content/posts/2022/microbit.md
+++ b/content/posts/2022/microbit.md
@@ -30,7 +30,7 @@ Programming is in my DNA, so when I had children it was obvious that I would att
 
 It was his birthday the other day and he got quite a few tech related things. First off he got some programming books. [Get Coding!](https://www.amazon.co.uk/gp/product/1406366846/ref=ppx_yo_dt_b_asin_title_o02_s01?ie=UTF8&psc=1), [Coding for Kids: Scratch:](https://www.amazon.co.uk/gp/product/1641522453/ref=ppx_yo_dt_b_asin_title_o02_s00?ie=UTF8&psc=1) and [Coding for Kids: Python:](https://www.amazon.co.uk/gp/product/1641521759/ref=ppx_yo_dt_b_asin_title_o01_s00?ie=UTF8&psc=1)
 
-He has been reading an old Javascript book, so I wanted to get him something a bit more up to date, so the Get Coding book should give him the basics of creating webpages and doing things with Javascript. He has been also been playing with [Scratch](/posts/scratch) for a while so the second book will definitely interest him. He also keeps mentioning Python, which I know nothing about, so even if he never reads it, I have something new to learn!
+He has been reading an old Javascript book, so I wanted to get him something a bit more up to date, so the Get Coding book should give him the basics of creating webpages and doing things with Javascript. He has been also been playing with [Scratch](/posts/2022/scratch/) for a while so the second book will definitely interest him. He also keeps mentioning Python, which I know nothing about, so even if he never reads it, I have something new to learn!
 
 As well as the books he got a BBC micro:bit (with some accessories!) from his grandparents. He has been playing with [MakeCode](https://makecode.microbit.org/#) which features a simulator of a micro:bit, so I thought he might like having a physical device in his hands. 
 

--- a/content/posts/2026/ai-wont-replace-developers.md
+++ b/content/posts/2026/ai-wont-replace-developers.md
@@ -27,7 +27,7 @@ As I write this, I have just been made redundant. AI is not being used to explai
 
 <blockquote class="twitter-tweet"><p lang="en" dir="ltr">I just got laid off..... Again...... I am still in shock. I loved my new job and was creating great impact but here we are again. Layoffs are not personal so I am ok but yeh will be looking for something new...... Again......</p>&mdash; Debbie O&#39;Brien (@debs_obrien) <a href="https://twitter.com/debs_obrien/status/2027171846743892254?ref_src=twsrc%5Etfw">February 27, 2026</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
-I listened to an excellent talk at [NDC London](/ndc-london-2026) by Debbie O'Brien about using AI to do amazing things with [Playwright MCP](https://youtu.be/Numb52aJkJw). If people who are using AI to its fullest are losing their jobs to AI, what hope is there for our industry? Are we all going to be writing AI prompts and that's it?
+I listened to an excellent talk at [NDC London](/posts/2026/ndc-london-2026/) by Debbie O'Brien about using AI to do amazing things with [Playwright MCP](https://youtu.be/Numb52aJkJw). If people who are using AI to its fullest are losing their jobs to AI, what hope is there for our industry? Are we all going to be writing AI prompts and that's it?
 
 But let's stop for a minute. Software development is an ever-changing industry. There is always something new to learn and this AI craze is no different.
 
@@ -281,7 +281,7 @@ The developers who thrive in this shift will be the ones who can hold the system
 
 Systems thinking is what stops an AI-generated "solution" from becoming a future incident.
 
-It's also why the old advice from [The Pragmatic Programmer](/pragmatic-programmer) matters even more now: remember the big picture.
+It's also why the old advice from [The Pragmatic Programmer](/posts/2025/pragmatic-programmer/) matters even more now: remember the big picture.
 
 Not "can we generate this function", but:
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Markdown-only href updates with no application or build logic changes; main risk is a wrong target URL causing a broken link.
> 
> **Overview**
> Updates **internal markdown links** across five blog posts so they use the site’s **year-based post paths** (and trailing slashes) instead of older dated or flat URL shapes.
> 
> In **`top-25-star-trek-characters`**, the “More Star Trek Content” section retargets three episode/article links from paths like `/posts/2016/01/07/...` to `/posts/2016/.../` style URLs. **`tips-for-developing-yourself`**, **`testing-for-expiring-ssl-certificates`**, **`microbit`**, and **`ai-wont-replace-developers`** fix cross-post references (Pluralsight, Let’s Encrypt, Scratch, NDC London, *The Pragmatic Programmer*) to match the same URL convention—no content or front matter changes beyond those hrefs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91fc7b7f68928e3ce02078301f7ccfdfc38a78fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->