### PR TITLE
newsletter

### DIFF
--- a/content/newsletter.md
+++ b/content/newsletter.md
@@ -64,9 +64,9 @@ Here's what I've been writing about lately:
 
 ## View Latest Newsletter
 
-- [January 2026](https://us11.campaign-archive.com/?u=110e046407cf8a34c93d56a4c&id=49cfe48cec)
-- [February 2026](https://us11.campaign-archive.com/?u=110e046407cf8a34c93d56a4c&id=b88bec7dc1)
-- [March 2026](https://us11.campaign-archive.com/?u=110e046407cf8a34c93d56a4c&id=3a95a0b889)
+- [April 2026](https://us11.campaign-archive.com/?u=110e046407cf8a34c93d56a4c&id=6a5eb0a6ef)
+- [May 2026](https://us11.campaign-archive.com/?u=110e046407cf8a34c93d56a4c&id=f19213fe61)
+- [June 2026](https://us11.campaign-archive.com/?u=110e046407cf8a34c93d56a4c&id=b64f934e95)
 
 ## 🎯 Ready to Join?
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to public archive URLs; no application logic or sensitive data.
> 
> **Overview**
> Updates the **View Latest Newsletter** section on the newsletter page: removes archive links for **January–March 2026** and adds **April–June 2026** Mailchimp campaign-archive URLs in the same bullet list format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe1bf671f80f0c452fb03760ae9ba5477b566e38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->