### PR TITLE
Remove dead Episode Atlas CSS rule

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -204,10 +204,6 @@
   box-shadow: none;
 }
 
-.episode-atlas-promo .card-body {
-  padding: 0;
-}
-
 .episode-atlas-promo__card {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic stylesheet cleanup only; no logic or markup changes.
> 
> **Overview**
> Removes the unused **`.episode-atlas-promo .card-body`** rule from `assets/css/custom.css` (the `padding: 0` override). Episode Atlas sidebar promo styling stays on **`.episode-atlas-promo.card`** and **`.episode-atlas-promo__card`**; this is a small dead-CSS cleanup with no intended visual change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9f31d3e992c0cf40db8aa2b1dc7e62cae177190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->