### PR TITLE
Feature/hugo fixes

### DIFF
--- a/.cursor/rules/funkysi1701-blog.mdc
+++ b/.cursor/rules/funkysi1701-blog.mdc
@@ -34,7 +34,7 @@ These rules apply to all edits in this repo. Prefer matching existing patterns (
 - **Blog posts (`content/posts/**/*.md`):** Front matter `title` must stay within **50–60 characters** (inclusive), and `description` within **110–160 characters** (inclusive). CI enforces this via `scripts/check_meta_titles.py` and `scripts/check_meta_descriptions.py` (`.github/workflows/meta-title-length.yml` and `meta-description-length.yml`). Fix out-of-range values before merge.
 - **Headings:** Use a single top-level Markdown heading per page where that matches the site’s heading structure (one primary in-page title). Use lower-level headings for sections.
 - **Open Graph / Twitter / JSON-LD:** Follow patterns the theme and existing `layouts/partials/head.html` (and related partials) already emit. When adding share imagery or new external hosts, ensure CSP, headers, and SWA config remain coherent—do not bolt on inline trackers or third-party scripts without a clear need and review.
-- **Language:** Site language is British English (`languageCode = 'en-gb'` in config); keep copy and spelling consistent unless a quoted source requires otherwise.
+- **Language:** Site language is British English (`locale = 'en-gb'` in config); keep copy and spelling consistent unless a quoted source requires otherwise.
 
 ## Testing and CI expectations
 

--- a/assets/service-worker/config.js
+++ b/assets/service-worker/config.js
@@ -1,0 +1,31 @@
+{{- $defaultRivision := now.Unix  -}}
+{{- $pages := slice -}}
+{{- range hugo.Sites -}}
+  {{- range .Pages -}}
+    {{- $revision := $defaultRivision -}}
+    {{- with .File -}}
+        {{- $revision = .UniqueID -}}
+    {{- end -}}
+    {{- $pages = $pages | append (dict "url" .Permalink "revision" $revision) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- partial "helpers/read-dir" (dict "Path" "/static" "Scratch" $.Scratch) -}}
+
+{{ if eq (len hugo.Sites) 1 }}
+  {{- $pages = $pages | append (dict "url" (printf "/%s" "manifest.json" | absURL) "revision" $defaultRivision)  -}}
+{{ else }}
+{{- range hugo.Sites -}}
+  {{- $pages = $pages | append (dict "url" (printf "/%s/%s" .Language.Lang "manifest.json" | absURL) "revision" $defaultRivision)  -}}
+{{- end -}}
+{{ end }}
+
+const pages = JSON.parse('{{ $pages | jsonify }}');
+const assets = JSON.parse('{{ $.Scratch.Get "hbs-assets" | jsonify }}');
+const multilingual = {{ if eq (len hugo.Sites) 1 }}false{{ else }}true{{ end }};
+const config = {
+    version: {{ now.Unix }},
+    multilingual: {{ if eq (len hugo.Sites) 1 }}false{{ else }}true{{ end }},
+    pages: pages,
+    assets: assets
+};

--- a/assets/service-worker/config.js
+++ b/assets/service-worker/config.js
@@ -1,10 +1,10 @@
-{{- $defaultRivision := now.Unix  -}}
+{{- $defaultRevision := now.Unix -}}
 {{- $pages := slice -}}
 {{- range hugo.Sites -}}
   {{- range .Pages -}}
-    {{- $revision := $defaultRivision -}}
+    {{- $revision := $defaultRevision -}}
     {{- with .File -}}
-        {{- $revision = .UniqueID -}}
+      {{- $revision = .UniqueID -}}
     {{- end -}}
     {{- $pages = $pages | append (dict "url" .Permalink "revision" $revision) -}}
   {{- end -}}
@@ -13,11 +13,11 @@
 {{- partial "helpers/read-dir" (dict "Path" "/static" "Scratch" $.Scratch) -}}
 
 {{ if eq (len hugo.Sites) 1 }}
-  {{- $pages = $pages | append (dict "url" (printf "/%s" "manifest.json" | absURL) "revision" $defaultRivision)  -}}
+  {{- $pages = $pages | append (dict "url" (printf "/%s" "manifest.json" | absURL) "revision" $defaultRevision) -}}
 {{ else }}
-{{- range hugo.Sites -}}
-  {{- $pages = $pages | append (dict "url" (printf "/%s/%s" .Language.Lang "manifest.json" | absURL) "revision" $defaultRivision)  -}}
-{{- end -}}
+  {{- range hugo.Sites -}}
+    {{- $pages = $pages | append (dict "url" (printf "/%s/%s" .Language.Lang "manifest.json" | absURL) "revision" $defaultRevision) -}}
+  {{- end -}}
 {{ end }}
 
 const pages = JSON.parse('{{ $pages | jsonify }}');

--- a/assets/service-worker/config.js
+++ b/assets/service-worker/config.js
@@ -20,9 +20,14 @@
   {{- end -}}
 {{ end }}
 
-const pages = JSON.parse('{{ $pages | jsonify }}');
-const assets = JSON.parse('{{ $.Scratch.Get "hbs-assets" | jsonify }}');
-const multilingual = {{ if eq (len hugo.Sites) 1 }}false{{ else }}true{{ end }};
+const pages = {{ $pages | jsonify }};
+const assets = {{ $.Scratch.Get "hbs-assets" | jsonify }};
+const config = {
+    version: {{ now.Unix }},
+    multilingual: {{ if eq (len hugo.Sites) 1 }}false{{ else }}true{{ end }},
+    pages,
+    assets
+};
 const config = {
     version: {{ now.Unix }},
     multilingual: {{ if eq (len hugo.Sites) 1 }}false{{ else }}true{{ end }},

--- a/assets/service-worker/config.js
+++ b/assets/service-worker/config.js
@@ -25,12 +25,6 @@ const assets = {{ $.Scratch.Get "hbs-assets" | jsonify }};
 const config = {
     version: {{ now.Unix }},
     multilingual: {{ if eq (len hugo.Sites) 1 }}false{{ else }}true{{ end }},
-    pages,
-    assets
-};
-const config = {
-    version: {{ now.Unix }},
-    multilingual: {{ if eq (len hugo.Sites) 1 }}false{{ else }}true{{ end }},
     pages: pages,
     assets: assets
 };

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,4 +1,4 @@
-languageCode = 'en-gb'
+locale = 'en-gb'
 title = "Funky Si's Blog"
 theme = 'hugo-theme-bootstrap'
 enableRobotsTXT = true

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -16,7 +16,7 @@
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.Locale }}
     <language>{{.}}</language>{{end}}{{ with .Site.Params.author.email }}
     <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.author.email }}
     <webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.LanguageCode }}">
+<html lang="{{ site.Language.Locale }}">
 <head>
   <meta charset="utf-8">
   <title>{{ .Title }}</title>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config and template field renames plus a new PWA cache manifest; no auth, payments, or sensitive data paths.
> 
> **Overview**
> Aligns the site with Hugo’s **`locale`** setting (replacing deprecated **`languageCode`**) and wires templates to **`.Site.Language.Locale`** for RSS `<language>` and alias-page **`html lang`**.
> 
> Adds a site-level **`assets/service-worker/config.js`** template that emits a build-time **`config`** object: cache version, per-page URLs with revisions, static assets from **`helpers/read-dir`**, and **`manifest.json`** URLs (single- vs multi-language).
> 
> Updates **`.cursor/rules/funkysi1701-blog.mdc`** so SEO/language guidance documents **`locale`** instead of **`languageCode`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44d2980c51ea97d213bd60e47861b5e00c1f66f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->