### PR TITLE
Fix duplicate service worker config declaration

### DIFF
--- a/assets/service-worker/config.js
+++ b/assets/service-worker/config.js
@@ -25,12 +25,6 @@ const assets = {{ $.Scratch.Get "hbs-assets" | jsonify }};
 const config = {
     version: {{ now.Unix }},
     multilingual: {{ if eq (len hugo.Sites) 1 }}false{{ else }}true{{ end }},
-    pages,
-    assets
-};
-const config = {
-    version: {{ now.Unix }},
-    multilingual: {{ if eq (len hugo.Sites) 1 }}false{{ else }}true{{ end }},
     pages: pages,
     assets: assets
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Template-only fix for duplicate JS output with no auth, data, or runtime logic changes beyond eliminating a syntax error.
> 
> **Overview**
> Removes a **duplicate `const config` declaration** in the Hugo-generated service worker config template so the built `config.js` only defines the object once.
> 
> The surviving `config` object still exposes `version`, `multilingual`, `pages`, and `assets`, now using explicit `pages` / `assets` properties instead of the removed duplicate block’s shorthand form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c01929622cc59bc76656f2e950208568f26eb16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->