### PR TITLE
Ensure Episode Atlas screenshots close browser

### DIFF
--- a/scripts/capture-episode-atlas-screenshots.mjs
+++ b/scripts/capture-episode-atlas-screenshots.mjs
@@ -37,25 +37,28 @@ const shots = [
 async function main() {
   await mkdir(outDir, { recursive: true });
   const browser = await chromium.launch({ headless: true });
-  const page = await browser.newPage({
-    viewport: { width: 1280, height: 800 },
-    userAgent:
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-  });
+  try {
+    const page = await browser.newPage({
+      viewport: { width: 1280, height: 800 },
+      userAgent:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    });
 
-  for (const s of shots) {
-    process.stdout.write(`Capturing ${s.name}…\n`);
-    await page.goto(s.url, { waitUntil: 'domcontentloaded', timeout: 90_000 });
-    if (s.extraMs) {
-      await page.waitForTimeout(s.extraMs);
+    for (const s of shots) {
+      process.stdout.write(`Capturing ${s.name}…\n`);
+      await page.goto(s.url, { waitUntil: 'domcontentloaded', timeout: 90_000 });
+      if (s.extraMs) {
+        await page.waitForTimeout(s.extraMs);
+      }
+      if (s.after) {
+        await s.after(page);
+      }
+      await page.screenshot({ path: join(outDir, `${s.name}.png`) });
     }
-    if (s.after) {
-      await s.after(page);
-    }
-    await page.screenshot({ path: join(outDir, `${s.name}.png`) });
+  } finally {
+    await browser.close();
   }
 
-  await browser.close();
   process.stdout.write(`Done. Wrote ${shots.length} files to ${outDir}\n`);
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Local dev/blog screenshot tooling only; no production runtime or security impact.
> 
> **Overview**
> Wraps the Playwright **page** setup and screenshot loop in a **`try`/`finally`** so **`browser.close()`** runs even when navigation, waits, hooks, or screenshots throw—avoiding leaked headless Chromium processes on failure.
> 
> The success log line still runs after cleanup; behavior on the happy path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c07e0d31dbc5f7026fbc3a8613b468fb41cce08e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->