### PR TITLE
Avoid inlining GitHub token in pipeline script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,6 +111,8 @@ steps:
 - task: PowerShell@2
   displayName: 'Notify GitHub (repository_dispatch: azure-pipeline-complete)'
   condition: and(succeeded(), ne(variables['Build.Reason'], 'Schedule'), or(in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/develop'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/')))
+  env:
+    GITHUB_TOKEN: $(GitHubToken)
   inputs:
     targetType: inline
     script: |
@@ -123,7 +125,7 @@ steps:
         -Method Post `
         -ContentType "application/json" `
         -Headers @{
-          Authorization = "Bearer $(GitHubToken)"
+          Authorization = "Bearer $env:GITHUB_TOKEN"
           Accept = "application/vnd.github+json"
           "X-GitHub-Api-Version" = "2022-11-28"
         } `


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only secret-handling change with the same API behavior; improves masking and reduces accidental token exposure in logs.
> 
> **Overview**
> The **Notify GitHub** `PowerShell@2` step now supplies the PAT via a task-level `env` mapping (`GITHUB_TOKEN: $(GitHubToken)`) instead of expanding `$(GitHubToken)` directly in the inline script’s `Authorization` header.
> 
> The REST call uses `Bearer $env:GITHUB_TOKEN`, so the secret is not embedded in the script text Azure DevOps stores and logs for that step—aligning with how other steps (e.g. Pa11y) already pass tokens through environment variables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2238c4a9dde3e4c37a9a9e4c18ceb6f3ca394ff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->