### PR TITLE
fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,28 +108,6 @@ steps:
   condition: and(succeeded(), ne(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranchName'], 'main'))
   displayName: 'helm upgrade blog (namespace main / prod)'
 
-- task: PowerShell@2
-  displayName: 'Notify GitHub (repository_dispatch: azure-pipeline-complete)'
-  condition: and(succeeded(), ne(variables['Build.Reason'], 'Schedule'), or(in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/develop'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/')))
-  env:
-    GITHUB_TOKEN: $(GITHUB_TOKEN)
-  inputs:
-    targetType: inline
-    script: |
-      $body = @{
-        event_type = "azure-pipeline-complete"
-      } | ConvertTo-Json
-
-      Invoke-RestMethod `
-        -Uri "https://api.github.com/repos/funkysi1701/funkysi1701.github.io/dispatches" `
-        -Method Post `
-        -ContentType "application/json" `
-        -Headers @{
-          Authorization = "Bearer $env:GITHUB_TOKEN"
-          Accept = "application/vnd.github+json"
-          "X-GitHub-Api-Version" = "2022-11-28"
-        } `
-        -Body $body
 - task: CmdLine@2
   displayName: 'Pa11y Accessibility Check (nightly only)'
   condition: and(succeeded(), eq(variables['Build.Reason'], 'Schedule'))
@@ -231,6 +209,28 @@ steps:
         -e SITE_URL="$SITE_URL" \
         node:20-alpine \
         node /app/scripts/create-accessibility-issues.js
+- task: PowerShell@2
+  displayName: 'Notify GitHub (repository_dispatch: azure-pipeline-complete)'
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'Schedule'), or(in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/develop'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/')))
+  env:
+    GITHUB_TOKEN: $(GITHUB_TOKEN)
+  inputs:
+    targetType: inline
+    script: |
+      $body = @{
+        event_type = "azure-pipeline-complete"
+      } | ConvertTo-Json
+
+      Invoke-RestMethod `
+        -Uri "https://api.github.com/repos/funkysi1701/funkysi1701.github.io/dispatches" `
+        -Method Post `
+        -ContentType "application/json" `
+        -Headers @{
+          Authorization = "Bearer $env:GITHUB_TOKEN"
+          Accept = "application/vnd.github+json"
+          "X-GitHub-Api-Version" = "2022-11-28"
+        } `
+        -Body $body        
 - task: CmdLine@2
   displayName: 'Fail build if site was unreachable during Pa11y'
   condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'Schedule'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -230,7 +230,7 @@ steps:
           Accept = "application/vnd.github+json"
           "X-GitHub-Api-Version" = "2022-11-28"
         } `
-        -Body $body        
+        -Body $body
 - task: CmdLine@2
   displayName: 'Fail build if site was unreachable during Pa11y'
   condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'Schedule'))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> YAML-only step reorder with no change to notify logic or deploy commands.
> 
> **Overview**
> Reorders the **Notify GitHub** (`repository_dispatch: azure-pipeline-complete`) PowerShell step in `azure-pipelines.yml` so it runs **after** the nightly Pa11y accessibility block (scan + `create-accessibility-issues.js`), instead of immediately after the Helm upgrade steps.
> 
> The dispatch payload, API call, and branch/`Build.Reason` conditions are unchanged; only step order in the pipeline definition moves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f159c3d4082fdccb0653b3feb2ce8dbf9bcd0456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->