### PR TITLE
Add permissions to SEO Check workflow

### DIFF
--- a/.github/workflows/seo-check.yml
+++ b/.github/workflows/seo-check.yml
@@ -1,5 +1,7 @@
 name: SEO Check
-
+permissions:
+  contents: read
+  
 on:
   repository_dispatch:
     types: [azure-pipeline-complete]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only least-privilege token scoping; no application or runtime behavior changes.
> 
> **Overview**
> Adds **workflow-level** `permissions: contents: read` to the SEO Check GitHub Actions workflow so the default `GITHUB_TOKEN` scope is limited to reading the repo, matching other workflows in this repo.
> 
> The `seo-crawl` job still declares **`pull-requests: write`** and **`issues: write`** for Signal Diff PR comments. Also fixes the missing newline at the end of `seo-check.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f24ff66201ec0fbfc539288e067972c0d6ba2d7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->