### PR TITLE
fix

### DIFF
--- a/.github/workflows/seo-check.yml
+++ b/.github/workflows/seo-check.yml
@@ -1,7 +1,7 @@
 name: SEO Check
 permissions:
   contents: read
-  
+
 on:
   repository_dispatch:
     types: [azure-pipeline-complete]
@@ -13,6 +13,21 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Checkout build commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.commit_sha || github.sha }}
+          fetch-depth: 2
+
+      - name: Resolve baseline commit
+        id: baseline
+        run: |
+          if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+            echo "sha=$(git rev-parse HEAD^)" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run Signal Diff crawl
         id: signal_diff
         uses: funkysi1701/signal-diff-action@v1.6
@@ -23,5 +38,8 @@ jobs:
           fail_mode: none
           execution_mode: agent
           comment_on_pr: false
-          collect_code_changes: false
+          collect_code_changes: true
+          commit_sha: ${{ github.event.client_payload.commit_sha || github.sha }}
+          ref_name: ${{ github.event.client_payload.ref_name || github.ref }}
+          baseline_ref: ${{ steps.baseline.outputs.sha }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -219,7 +219,11 @@ steps:
     script: |
       $body = @{
         event_type = "azure-pipeline-complete"
-      } | ConvertTo-Json
+        client_payload = @{
+          commit_sha = "$(Build.SourceVersion)"
+          ref_name = "$(Build.SourceBranch)"
+        }
+      } | ConvertTo-Json -Depth 5
 
       Invoke-RestMethod `
         -Uri "https://api.github.com/repos/funkysi1701/funkysi1701.github.io/dispatches" `


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to CI wiring (dispatch payload, checkout, and Signal Diff inputs) with no application runtime or auth impact.
> 
> **Overview**
> After Azure finishes a non-scheduled build on **main**, **develop**, or **feature/***, the pipeline’s `repository_dispatch` now includes **`commit_sha`** and **`ref_name`** in `client_payload` so GitHub Actions can target the same revision that was deployed.
> 
> The **SEO Check** workflow uses that payload: it **checks out** the build commit (with `fetch-depth: 2`), derives a **baseline** as `HEAD^` when available, and passes **`commit_sha`**, **`ref_name`**, and **`baseline_ref`** into **Signal Diff** with **`collect_code_changes: true`** so the post-deploy crawl can relate SEO results to the code diff—not just the default checkout ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48f954a0b5ca639305f0a714dc4cc64ef6c1e33c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->