### PR TITLE
add workflow dispatch

### DIFF
--- a/.github/workflows/seo-check.yml
+++ b/.github/workflows/seo-check.yml
@@ -3,6 +3,7 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
   repository_dispatch:
     types: [azure-pipeline-complete]
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Trigger-only change to CI; no application or secret-handling logic is modified.
> 
> **Overview**
> Adds **`workflow_dispatch`** to the **SEO Check** workflow so the Signal Diff crawl can be started manually from the Actions tab, without waiting for an **`azure-pipeline-complete`** repository dispatch.
> 
> The existing **`repository_dispatch`** trigger is unchanged; this only adds an on-demand run path consistent with other maintenance workflows in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 702970c9cd7f80501c30bfcb73288a03b45c5c5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->