### PR TITLE
add delay

### DIFF
--- a/.github/workflows/seo-check.yml
+++ b/.github/workflows/seo-check.yml
@@ -10,6 +10,10 @@ on:
 jobs:
   seo-crawl:
     runs-on: ubuntu-latest
+    # Avoid overlapping agent crawls when Azure dispatches back-to-back.
+    concurrency:
+      group: seo-crawl-blog-dev
+      cancel-in-progress: true
     permissions:
       contents: read
       pull-requests: write
@@ -28,6 +32,25 @@ jobs:
           else
             echo "sha=" >> "$GITHUB_OUTPUT"
           fi
+
+      # Azure repository_dispatch runs as soon as Helm --wait returns; blog-dev ingress/CDN
+      # can lag behind the cluster (same pattern as Pa11y readiness in azure-pipelines.yml).
+      - name: Wait for blog-dev sitemap
+        if: github.event_name == 'repository_dispatch'
+        run: |
+          set -euo pipefail
+          url="https://blog-dev.funkysi1701.com/sitemap.xml"
+          for i in $(seq 1 36); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" "$url" || true)
+            if [ "$code" = "200" ]; then
+              echo "blog-dev sitemap ready (HTTP 200) on attempt ${i}"
+              exit 0
+            fi
+            echo "Attempt ${i}: HTTP ${code:-curl-failed}; retrying in 10s..."
+            sleep 10
+          done
+          echo "blog-dev sitemap did not return HTTP 200 within ~6 minutes"
+          exit 1
 
       - name: Run Signal Diff crawl
         id: signal_diff


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no application runtime, auth, or data handling impact.
> 
> **Overview**
> The **SEO Check** workflow is hardened for Azure-triggered runs that fire right after deploy.
> 
> A **concurrency** group (`seo-crawl-blog-dev`, cancel in progress) stops overlapping Signal Diff agent crawls when `repository_dispatch` events arrive close together.
> 
> For **`repository_dispatch` only**, a new step polls `https://blog-dev.funkysi1701.com/sitemap.xml` until HTTP 200 (up to ~6 minutes, 10s intervals) so the crawl does not start before blog-dev ingress/CDN is actually serving the new build—mirroring the Pa11y readiness pattern in Azure Pipelines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f489c53f6410856f0bfb031680748233b8c720. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->