### PR TITLE
fix check

### DIFF
--- a/.github/workflows/seo-check.yml
+++ b/.github/workflows/seo-check.yml
@@ -42,14 +42,14 @@ jobs:
           url="https://blog-dev.funkysi1701.com/sitemap.xml"
           for i in $(seq 1 36); do
             code=$(curl -s -o /dev/null -w "%{http_code}" "$url" || true)
-            if [ "$code" = "200" ]; then
-              echo "blog-dev sitemap ready (HTTP 200) on attempt ${i}"
+            if [ "$code" = "304" ]; then
+              echo "blog-dev sitemap ready (HTTP 304) on attempt ${i}"
               exit 0
             fi
             echo "Attempt ${i}: HTTP ${code:-curl-failed}; retrying in 10s..."
             sleep 10
           done
-          echo "blog-dev sitemap did not return HTTP 200 within ~6 minutes"
+          echo "blog-dev sitemap did not return HTTP 304 within ~6 minutes"
           exit 1
 
       - name: Run Signal Diff crawl


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only readiness condition change with no application or security impact.
> 
> **Overview**
> The **Wait for blog-dev sitemap** step in `.github/workflows/seo-check.yml` now treats the sitemap as ready when `curl` gets **HTTP 304** instead of **HTTP 200**, including updated log and failure messages.
> 
> This only affects the `repository_dispatch` readiness loop before the Signal Diff crawl; retry timing and the rest of the workflow are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5433b2c0553828cd9ec1340cc68c15f2909dcf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->