### PR TITLE
ff

### DIFF
--- a/.github/workflows/seo-check.yml
+++ b/.github/workflows/seo-check.yml
@@ -50,7 +50,7 @@ jobs:
             sleep 10
           done
           echo "blog-dev sitemap did not return HTTP 304 within ~6 minutes"
-          exit 1
+          exit 0
 
       - name: Run Signal Diff crawl
         id: signal_diff


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only softens a CI guard; crawls may run before the sitemap is ready, but Signal Diff is already configured with fail_mode none.
> 
> **Overview**
> The **SEO Check** workflow no longer fails when the blog-dev sitemap wait step times out (~6 minutes without HTTP **304**). That step now exits **0** instead of **1**, so the job continues to the Signal Diff crawl even if the sitemap is not ready yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eceafc5e8bba9923c4ac838818cf747c1bc3608e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->