### PR TITLE
try ah

### DIFF
--- a/.github/workflows/seo-check.yml
+++ b/.github/workflows/seo-check.yml
@@ -33,25 +33,6 @@ jobs:
             echo "sha=" >> "$GITHUB_OUTPUT"
           fi
 
-      # Azure repository_dispatch runs as soon as Helm --wait returns; blog-dev ingress/CDN
-      # can lag behind the cluster (same pattern as Pa11y readiness in azure-pipelines.yml).
-      - name: Wait for blog-dev sitemap
-        if: github.event_name == 'repository_dispatch'
-        run: |
-          set -euo pipefail
-          url="https://blog-dev.funkysi1701.com/sitemap.xml"
-          for i in $(seq 1 36); do
-            code=$(curl -s -o /dev/null -w "%{http_code}" "$url" || true)
-            if [ "$code" = "304" ]; then
-              echo "blog-dev sitemap ready (HTTP 304) on attempt ${i}"
-              exit 0
-            fi
-            echo "Attempt ${i}: HTTP ${code:-curl-failed}; retrying in 10s..."
-            sleep 10
-          done
-          echo "blog-dev sitemap did not return HTTP 304 within ~6 minutes"
-          exit 0
-
       - name: Run Signal Diff crawl
         id: signal_diff
         uses: funkysi1701/signal-diff-action@v1.6

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,6 +217,28 @@ steps:
   inputs:
     targetType: inline
     script: |
+      # blog-dev is not reachable from GitHub-hosted runners (curl HTTP 000 there).
+      # Wait here on the pipeline agent before dispatching the SEO workflow.
+      $sitemapUrl = "https://blog-dev.funkysi1701.com/sitemap.xml"
+      $ready = $false
+      for ($i = 1; $i -le 36; $i++) {
+        try {
+          $resp = Invoke-WebRequest -Uri $sitemapUrl -Method Get -UseBasicParsing -TimeoutSec 30
+          if ($resp.StatusCode -eq 200) {
+            Write-Host "blog-dev sitemap ready (HTTP 200) on attempt $i"
+            $ready = $true
+            break
+          }
+          Write-Host "Attempt ${i}: HTTP $($resp.StatusCode); retrying in 10s..."
+        } catch {
+          Write-Host "Attempt ${i}: $($_.Exception.Message); retrying in 10s..."
+        }
+        Start-Sleep -Seconds 10
+      }
+      if (-not $ready) {
+        Write-Host "##vso[task.logissue type=warning]blog-dev sitemap did not return HTTP 200 within ~6 minutes; dispatching SEO Check anyway."
+      }
+
       $body = @{
         event_type = "azure-pipeline-complete"
         client_payload = @{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only timing change for SEO workflow trigger; no application auth, data, or runtime behavior changes.
> 
> **Overview**
> Moves **blog-dev sitemap readiness** from the GitHub **SEO Check** workflow into the Azure pipeline step that fires `repository_dispatch`, because **blog-dev is not reachable from GitHub-hosted runners** (curl reported HTTP 000).
> 
> The workflow **removes** the `repository_dispatch`-only **Wait for blog-dev sitemap** step (curl loop expecting **HTTP 304**, up to ~6 minutes, and previously exited 0 on timeout). The **Notify GitHub** PowerShell task **adds** an equivalent wait on the **pipeline agent** (up to 36 × 10s) using `Invoke-WebRequest` until **HTTP 200**, then dispatches the SEO workflow; if the sitemap never becomes ready, it logs a **warning** and still dispatches.
> 
> This aligns SEO crawling timing with deploy/ingress lag on infrastructure the agent can reach, similar in spirit to existing Pa11y public-URL waits in the same pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52208b685ac9d1540308929e5c484d4dd6e6734f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->