### PR TITLE
3266

### DIFF
--- a/.cursor/rules/funkysi1701-blog.mdc
+++ b/.cursor/rules/funkysi1701-blog.mdc
@@ -52,7 +52,7 @@ These rules apply to all edits in this repo. Prefer matching existing patterns (
 ## Documentation (Markdown)
 
 - Tracked **`*.md`** files are part of the repo contract. When a change affects anything they describe (Hugo commands, Docker, CI, env vars, deploy steps, or testing), **update every affected Markdown file in the same change** so commands and paths stay accurate.
-- At minimum, keep **`README.md`**, **`.github/copilot-instructions.md`**, and **this rules file** (`.cursor/rules/funkysi1701-blog.mdc`) aligned with real behaviour when workflows, branches, testing, or content automation shift; search for other **`*.md`** mentions of the same topic and fix stale references.
+- At minimum, keep **`AGENTS.md`**, **`README.md`**, **`.github/copilot-instructions.md`**, and **this rules file** (`.cursor/rules/funkysi1701-blog.mdc`) aligned with real behaviour when workflows, branches, testing, or content automation shift; search for other **`*.md`** mentions of the same topic and fix stale references. **`AGENTS.md`** is the portable agent onboarding layer — keep it concise and link here for detail rather than duplicating this file.
 - Do **not** add new Markdown files unless the user or task explicitly asks for them; prefer updating existing docs.
 
 ## Scope of changes

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,7 @@
+public/
+node_modules/
+themes/hugo-theme-bootstrap/
+playwright-report/
+test-results/
+coverage/
+.playwright-mcp/

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,7 @@
 # Copilot Instructions for funkysi1701.com Blog
 
+For a shorter, tool-agnostic onboarding guide, see **[`AGENTS.md`](../AGENTS.md)** at the repo root. This file adds Copilot-specific detail; full Cursor rules live in **`.cursor/rules/funkysi1701-blog.mdc`**.
+
 ## Project Overview
 
 This is a personal blog/portfolio website powered by **Hugo** (static site generator), hosted on Azure Static Web Apps with infrastructure managed through **Kubernetes + Helm**. The site features blog posts, projects, podcasts, and technical content, primarily focused on .NET, Azure, and DevOps topics.

--- a/.github/workflows/meta-title-length.yml
+++ b/.github/workflows/meta-title-length.yml
@@ -5,9 +5,6 @@ permissions:
   issues: write
 
 on:
-  push:
-    branches: [main]
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/meta-title-length.yml
+++ b/.github/workflows/meta-title-length.yml
@@ -5,6 +5,9 @@ permissions:
   issues: write
 
 on:
+  push:
+    branches: [main]
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# Agent onboarding — funkysi1701.com (Hugo blog)
+
+Portable guide for AI agents (Cursor, Copilot, Claude Code, etc.). For full conventions, see [`.cursor/rules/funkysi1701-blog.mdc`](.cursor/rules/funkysi1701-blog.mdc) and [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
+
+**Site:** https://www.funkysi1701.com
+
+## Quick start
+
+| Task | Command |
+|------|---------|
+| Local dev server | `hugo server -D` → http://localhost:1313 |
+| Production build | `hugo --minify --environment production` |
+| Docker dev | `docker-compose up` (Hugo version from `.env`) |
+| Install test deps | `npm ci` |
+| E2E tests | `npm test` (set `BASE_URL` for non-production targets) |
+| Playwright browser | `npx playwright install chromium` |
+| Meta title check | `python scripts/check_meta_titles.py --root .` |
+| Meta description check | `python scripts/check_meta_descriptions.py --root .` |
+| Parkrun results update | `pip install -r scripts/requirements-parkrun.txt` then `python scripts/update_parkrun_results.py` |
+
+After changing `package.json` or `package-lock.json`, run `npm ci` before `npm test` (matches Azure DevOps).
+
+## What not to edit
+
+- **`public/`** — Hugo build output; never commit as source of truth.
+- **Parkrun generated block** in `content/parkrun.md` between `<!-- BEGIN PARKRUN_GENERATED -->` and `<!-- END PARKRUN_GENERATED -->` — produced by `scripts/update_parkrun_results.py`. Edit content below the markers by hand; optional row suppressions in `data/parkrun_suppress.json`.
+- **Secrets** — no API keys, deploy tokens, or credentials in `.env`, `config/`, or front matter. Azure Static Web Apps deploy token lives only in GitHub Actions secrets.
+- **Vendored theme** — prefer site overrides in root `layouts/`, `assets/`, and `static/` over editing `themes/hugo-theme-bootstrap/`.
+
+## Source of truth
+
+- **Content:** `content/` (posts under `content/posts/YYYY/`, pages at `content/` root).
+- **Config:** `config/_default/` plus `config/development/`, `config/staging/`, `config/production/` when environment-specific.
+- **Templates & assets:** `layouts/`, `assets/`, `static/`.
+- **Routing / headers:** `staticwebapp.config.json` (copied into `public/` on deploy).
+
+## Blog post guardrails
+
+Posts (`content/posts/**/*.md`) use TOML front matter in `+++` fences. CI enforces:
+
+- **`title`:** 50–60 characters (inclusive)
+- **`description`:** 110–160 characters (inclusive)
+
+British English (`locale = 'en-gb'`). One top-level Markdown heading per page where that matches site structure. Meaningful images need descriptive alt text.
+
+## CI map
+
+| Check | Where | Notes |
+|-------|-------|-------|
+| Playwright E2E | **Azure Pipelines** — `azure-pipelines-playwright.yml` | Primary full E2E gate; `BASE_URL` from branch (`main`/`master` → production, `develop` → blog-dev) |
+| Page coverage / Codecov | Azure Pipelines | `scripts/generate-page-coverage.js`; informational per `codecov.yml` |
+| Meta title / description length | **GitHub Actions** | `meta-title-length.yml`, `meta-description-length.yml` |
+| Azure SWA deploy | GitHub Actions | `azure-static-web-apps-victorious-pebble-0b8f90e03.yml` (production path) |
+| Broken links | GitHub Actions | `link.yml` — monthly + manual; crawls from production homepage |
+| Parkrun scrape PR | GitHub Actions | `parkrun-update.yml` — PR to `develop` when scrape succeeds |
+| develop → main PR | GitHub Actions | `auto-pr.yml` |
+| SEO crawl (Signal Diff) | GitHub Actions | `seo-check.yml` — triggered after Azure pipeline or manually |
+| Image build + Helm deploy | Azure Pipelines | `azure-pipelines.yml` — ECR push and Kubernetes deploy |
+
+A green GitHub Actions run does **not** imply Playwright passed — check Azure Pipelines for E2E.
+
+## Branches and deploy
+
+| Branch | Target |
+|--------|--------|
+| **`main`** | Production — SWA (GHA) + Helm `main` namespace |
+| **`develop`** | Integration — Helm `develop` and `test` namespaces (blog-dev / blog-test) |
+| **`feature/*`** | Build and Helm to `develop` namespace only |
+
+There is no `dev` branch; use **`develop`**. `.github/workflows/auto-pr.yml` can open or refresh a develop → main PR.
+
+## Scope
+
+Make the smallest change that satisfies the task. Do not refactor unrelated code or add dependencies without clear need.
+
+## Further reading
+
+| Path | Purpose |
+|------|---------|
+| [`.cursor/rules/funkysi1701-blog.mdc`](.cursor/rules/funkysi1701-blog.mdc) | Full Cursor rules (always applied in Cursor) |
+| [`.github/copilot-instructions.md`](.github/copilot-instructions.md) | Copilot-specific project context |
+| [`README.md`](README.md) | Human-oriented setup, testing, and deploy |
+| [`specs/funkysi1701-test-plan.md`](specs/funkysi1701-test-plan.md) | E2E scenario plan (`// spec:` comments in `tests/`) |
+| [`.vscode/mcp.json`](.vscode/mcp.json) | Playwright MCP server for agent-driven test runs |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,10 @@ After changing `package.json` or `package-lock.json`, run `npm ci` before `npm t
 - **Secrets** — no API keys, deploy tokens, or credentials in `.env`, `config/`, or front matter. Azure Static Web Apps deploy token lives only in GitHub Actions secrets.
 - **Vendored theme** — prefer site overrides in root `layouts/`, `assets/`, and `static/` over editing `themes/hugo-theme-bootstrap/`.
 
+## Cursor context
+
+**`.cursorignore`** keeps Cursor Agent indexing off generated and vendored paths (`public/`, `node_modules/`, `themes/hugo-theme-bootstrap/`, Playwright/coverage artefacts). It affects Cursor only — not git or Hugo. Theme work still belongs in root `layouts/`, `assets/`, and `static/`.
+
 ## Source of truth
 
 - **Content:** `content/` (posts under `content/posts/YYYY/`, pages at `content/` root).

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ To run with Docker directly:
 docker run --rm -it -v .:/src -p 1313:1313 floryn90/hugo:${HUGO_VERSION} server -D --disableFastRender --environment development
 ```
 
+## 🤖 AI-assisted development
+
+Agents and coding assistants should start with **[`AGENTS.md`](AGENTS.md)** — a concise, tool-agnostic onboarding guide (build commands, guardrails, CI map, branch model). Deeper context lives in [`.cursor/rules/funkysi1701-blog.mdc`](.cursor/rules/funkysi1701-blog.mdc) (Cursor) and [`.github/copilot-instructions.md`](.github/copilot-instructions.md) (Copilot).
+
 ## 🧪 Testing
 
 End-to-end tests use **[Playwright](https://playwright.dev/)** (`@playwright/test`). Playwright tests (spec files) live under `tests/`; many files reference the high-level plan in **`specs/funkysi1701-test-plan.md`** (see `specs/README.md`).

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ docker run --rm -it -v .:/src -p 1313:1313 floryn90/hugo:${HUGO_VERSION} server 
 
 Agents and coding assistants should start with **[`AGENTS.md`](AGENTS.md)** — a concise, tool-agnostic onboarding guide (build commands, guardrails, CI map, branch model). Deeper context lives in [`.cursor/rules/funkysi1701-blog.mdc`](.cursor/rules/funkysi1701-blog.mdc) (Cursor) and [`.github/copilot-instructions.md`](.github/copilot-instructions.md) (Copilot).
 
+**Cursor:** [`.cursorignore`](.cursorignore) excludes Hugo build output, `node_modules/`, the vendored theme, and test artefacts from agent indexing; site overrides live in root `layouts/`, `assets/`, and `static/`.
+
 ## 🧪 Testing
 
 End-to-end tests use **[Playwright](https://playwright.dev/)** (`@playwright/test`). Playwright tests (spec files) live under `tests/`; many files reference the high-level plan in **`specs/funkysi1701-test-plan.md`** (see `specs/README.md`).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and Cursor indexing configuration only; no Hugo, CI, or runtime behaviour changes.
> 
> **Overview**
> Introduces **`AGENTS.md`** as a short, tool-agnostic onboarding doc for AI assistants (commands, guardrails, CI map, branch/deploy model) with links to Cursor rules and Copilot instructions instead of duplicating them.
> 
> Adds **`.cursorignore`** so Cursor Agent skips indexing Hugo output, `node_modules/`, the vendored theme, and Playwright/coverage artefacts. **`README.md`** gains an **AI-assisted development** section; **`.github/copilot-instructions.md`** and **`.cursor/rules/funkysi1701-blog.mdc`** now treat **`AGENTS.md`** as part of the doc set that must stay aligned when workflows or automation change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a5044a58b1cc2892813af5a33b92debbfac44e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->