### PR TITLE
3271

### DIFF
--- a/.cursor/rules/funkysi1701-blog-core.mdc
+++ b/.cursor/rules/funkysi1701-blog-core.mdc
@@ -5,7 +5,7 @@ alwaysApply: true
 
 # funkysi1701.com (Hugo blog) — core rules
 
-Portable onboarding: [`AGENTS.md`](../../AGENTS.md). Copilot detail: [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md). Path-scoped rules in [`.cursor/rules/`](.) activate for content, tests, layouts, and parkrun.
+Portable onboarding: [`AGENTS.md`](../../AGENTS.md). PR checklist: [`CONTRIBUTING.md`](../../CONTRIBUTING.md). Copilot detail: [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md). Path-scoped rules in [`.cursor/rules/`](.) activate for content, tests, layouts, and parkrun.
 
 Prefer matching existing patterns (Hugo TOML front matter in `+++` fences, site overrides under root `layouts/` and `static/`).
 
@@ -43,7 +43,7 @@ No **`dev`** branch — use **`develop`**. `.github/workflows/auto-pr.yml` can o
 ## Documentation
 
 - Tracked **`*.md`** is part of the repo contract. When a change affects documented behaviour, update every affected Markdown file in the same change.
-- Keep **`AGENTS.md`**, **`README.md`**, **`.github/copilot-instructions.md`**, and **`.cursor/rules/`** aligned when workflows, branches, testing, or automation shift. Do not add new Markdown files unless the user or task asks.
+- Keep **`AGENTS.md`**, **`CONTRIBUTING.md`**, **`README.md`**, **`.github/copilot-instructions.md`**, and **`.cursor/rules/`** aligned when workflows, branches, testing, or automation shift. Do not add new Markdown files unless the user or task asks.
 
 ## Scope
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Copilot Instructions for funkysi1701.com Blog
 
-For a shorter, tool-agnostic onboarding guide, see **[`AGENTS.md`](../AGENTS.md)** at the repo root. This file adds Copilot-specific detail. Cursor rules are path-scoped under **[`.cursor/rules/`](../.cursor/rules/)** — always-applied core in **`funkysi1701-blog-core.mdc`**, plus **`content-posts.mdc`**, **`playwright-tests.mdc`**, **`hugo-layouts.mdc`**, and **`parkrun-generated.mdc`**.
+For a shorter, tool-agnostic onboarding guide, see **[`AGENTS.md`](../AGENTS.md)** at the repo root. PR checklist and merge readiness: **[`CONTRIBUTING.md`](../CONTRIBUTING.md)**. This file adds Copilot-specific detail. Cursor rules are path-scoped under **[`.cursor/rules/`](../.cursor/rules/)** — always-applied core in **`funkysi1701-blog-core.mdc`**, plus **`content-posts.mdc`**, **`playwright-tests.mdc`**, **`hugo-layouts.mdc`**, and **`parkrun-generated.mdc`**.
 
 ## Project Overview
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,5 +92,6 @@ Make the smallest change that satisfies the task. Do not refactor unrelated code
 | [`.cursor/rules/parkrun-generated.mdc`](.cursor/rules/parkrun-generated.mdc) | parkrun generated block and update script |
 | [`.github/copilot-instructions.md`](.github/copilot-instructions.md) | Copilot-specific project context |
 | [`README.md`](README.md) | Human-oriented setup, testing, and deploy |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | PR checklist, branch workflow, merge readiness |
 | [`specs/funkysi1701-test-plan.md`](specs/funkysi1701-test-plan.md) | E2E scenario plan (`// spec:` comments in `tests/`) |
 | [`.vscode/mcp.json`](.vscode/mcp.json) | Playwright MCP server for agent-driven test runs |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to funkysi1701.com
+
+Thank you for contributing to this Hugo blog. Use this checklist before opening or reviewing a pull request. Setup, commands, and CI details live in [`README.md`](README.md); agents should also read [`AGENTS.md`](AGENTS.md).
+
+## Pull request checklist
+
+Copy into your PR description or verify locally before requesting review:
+
+- [ ] **Post front matter:** `title` 50–60 characters and `description` 110–160 characters for `content/posts/**/*.md`. Run `npm run check:meta` after editing front matter.
+- [ ] **Parkrun generated block:** Did not hand-edit `content/parkrun.md` between `<!-- BEGIN PARKRUN_GENERATED -->` and `<!-- END PARKRUN_GENERATED -->`. Use `scripts/update_parkrun_results.py` instead; see [`README.md`](README.md#parkrun-results-contentparkrunmd).
+- [ ] **Secrets and build output:** Did not commit API keys, deploy tokens, or credentials. Did not commit `public/` (Hugo build output).
+- [ ] **Templates and assets:** Local Hugo build passes (`hugo server -D` or `hugo --minify --environment production` as appropriate). Prefer site overrides in root `layouts/`, `assets/`, and `static/` over editing `themes/hugo-theme-bootstrap/`.
+- [ ] **Test changes:** `npm ci && npm test` when you change tests or behaviour they cover. Full Playwright E2E runs on **Azure Pipelines** (`azure-pipelines-playwright.yml`), not on GitHub Actions PR checks — a green GHA run does not imply E2E passed.
+- [ ] **New Playwright specs:** Include a `// spec: specs/funkysi1701-test-plan.md` comment (or the relevant scenario doc under `specs/`). See [`specs/funkysi1701-test-plan.md`](specs/funkysi1701-test-plan.md).
+
+## Branch workflow
+
+| Branch | Use |
+|--------|-----|
+| **`feature/*`** | Day-to-day work — open PRs into **`develop`** |
+| **`develop`** | Integration; Azure Pipelines deploys to blog-dev / blog-test |
+| **`main`** | Production; promotion via [`.github/workflows/auto-pr.yml`](.github/workflows/auto-pr.yml) (develop → main) |
+
+There is no **`dev`** branch — use **`develop`**.
+
+## AI-assisted contributions
+
+- Start with [`AGENTS.md`](AGENTS.md) for commands, guardrails, and the CI map.
+- Cursor: path-scoped rules in [`.cursor/rules/`](.cursor/rules/) (always-applied [`funkysi1701-blog-core.mdc`](.cursor/rules/funkysi1701-blog-core.mdc) plus content, tests, layouts, and parkrun rules). Copilot: [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
+- Playwright MCP for agent-driven test runs: [`.vscode/mcp.json`](.vscode/mcp.json).
+- Prefer **minimal diffs** — solve the task without refactoring unrelated code or adding dependencies without clear need.
+
+## Further reading
+
+| Path | Purpose |
+|------|---------|
+| [`README.md`](README.md) | Local setup, testing, deployment |
+| [`AGENTS.md`](AGENTS.md) | Tool-agnostic agent onboarding |
+| [`.cursor/rules/`](.cursor/rules/) | Cursor rules by area |
+| [`specs/funkysi1701-test-plan.md`](specs/funkysi1701-test-plan.md) | E2E scenario plan |

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ There is no separate branch named `dev`; use **`develop`** for integration work.
 
 ## 🤝 Contributing
 
-Open to suggestions and improvements. Feel free to submit PRs!
+Open to suggestions and improvements. See **[`CONTRIBUTING.md`](CONTRIBUTING.md)** for the PR checklist, branch workflow, and AI-assisted contribution notes.
 
 ## 👤 Author
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only; no application, CI, or deployment behaviour changes.
> 
> **Overview**
> Adds **`CONTRIBUTING.md`** as the canonical PR and review checklist: post meta (`npm run check:meta`), parkrun generated block rules, secrets/`public/`, Hugo overrides, Playwright vs Azure Pipelines E2E, and `// spec:` for new tests, plus branch workflow and AI-assisted contribution pointers.
> 
> **`README.md`**, **`AGENTS.md`**, **`.github/copilot-instructions.md`**, and **`.cursor/rules/funkysi1701-blog-core.mdc`** now link to or require keeping **`CONTRIBUTING.md`** in sync with the other repo-contract docs when workflows or automation change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bc9ce34fe9d9ee4de1bae1aa8aadd5dc2c47da7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->