### PR TITLE
fix canonical links

### DIFF
--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -34,6 +34,7 @@
   {{- end -}}
   <meta name="description" content="{{ $pageDesc }}">
   <meta name="robots" content="noindex,follow">
+  <link rel="canonical" href="{{ .Permalink }}" itemprop="url" />
   <meta property="og:title" content="{{ $title }}">
   <meta property="og:description" content="{{ $pageDesc }}">
   <meta property="og:url" content="{{ .Permalink }}">

--- a/layouts/partials/head/canonical.html
+++ b/layouts/partials/head/canonical.html
@@ -3,8 +3,12 @@
 <link rel="canonical" href="{{ . | relLangURL }}" itemprop="url" />
 {{ else }}
   {{- $canonical := .Permalink -}}
-  {{- if strings.Contains .RelPermalink "/page/" -}}
-    {{- $canonical = .RelPermalink | absLangURL -}}
+  {{- if or .IsHome (eq .Kind "taxonomy") (eq .Kind "term") (eq .Kind "section") -}}
+    {{- with .Paginator -}}
+      {{- if gt .PageNumber 1 -}}
+        {{- $canonical = .URL | absLangURL -}}
+      {{- end -}}
+    {{- end -}}
   {{- end -}}
 <link rel="canonical" href="{{ $canonical }}" itemprop="url" />
 {{ end }}

--- a/layouts/partials/head/schema-collection-page.html
+++ b/layouts/partials/head/schema-collection-page.html
@@ -1,8 +1,10 @@
 {{- $page := .page -}}
 {{- $pageDesc := printf "%s - %s" $page.Title ($page.Site.Params.description | default "") | plainify | htmlUnescape -}}
 {{- $pageURL := $page.Permalink -}}
-{{- if strings.Contains $page.RelPermalink "/page/" -}}
-  {{- $pageURL = $page.RelPermalink | absLangURL -}}
+{{- with $page.Paginator -}}
+  {{- if gt .PageNumber 1 -}}
+    {{- $pageURL = .URL | absLangURL -}}
+  {{- end -}}
 {{- end -}}
 {{- $website := dict "@type" "WebSite" "@id" (printf "%s#website" $page.Site.Home.Permalink) "name" $page.Site.Title "url" $page.Site.Home.Permalink -}}
 {{- $collection := dict "@type" "CollectionPage" "@id" (printf "%s#webpage" $pageURL) "url" $pageURL "name" $page.Title "description" $pageDesc "isPartOf" $website -}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> SEO head/metadata only; no auth, data, or routing logic beyond URL selection for canonical and schema.
> 
> **Overview**
> **Canonical URLs** for paginated list pages now use Hugo’s **Paginator** (page 2+ on home, sections, taxonomies, and terms) instead of detecting `/page/` in `RelPermalink`, so `rel="canonical"` matches the URL users actually see.
> 
> **Alias redirect pages** (`alias.html`) now emit a **canonical link** to `.Permalink` alongside existing `noindex` meta.
> 
> **CollectionPage JSON-LD** in `schema-collection-page.html` uses the same paginator-based URL so structured data stays aligned with the canonical tag on paginated archives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b1a60f9205da14066a3953455ec5c1883a9226c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->