### PR TITLE
fix

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -3,9 +3,9 @@
   <div class="container">
     <div class="row card component">
       <div class="card-header">
-        <h1 class="card-title">
+        <h2 class="card-title">
           Search
-        </h1>
+        </h2>
       </div>
       <div class="card-body">
         <div class="post-meta mb-3">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single markup change on the search layout with no logic or data impact.
> 
> **Overview**
> Changes the search page section title from **`h1`** to **`h2`** in `layouts/_default/search.html`, keeping the same `card-title` styling.
> 
> This avoids a second top-level heading on the search page, where the layout header already provides the page **`h1`** (site brand). It also matches the sidebar search block and search result titles, which already use **`h2`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ffaecacb3fa25e00f5f503257a1b95acd906cdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->