### PR TITLE
docs: enhance SEO and improve pagination handling

### DIFF
--- a/.cursor/rules/hugo-layouts.mdc
+++ b/.cursor/rules/hugo-layouts.mdc
@@ -22,6 +22,8 @@ Or Docker Compose / commands in `README.md` (Hugo version from `.env`).
 ## SEO partials
 
 - Document `<title>`: `layouts/partials/head/title.html` (home falls back to `Site.Title`).
+- List/archive meta descriptions: `layouts/partials/head/list-page-description.html` (pagination suffix on page 2+).
+- Paginated list `noindex`: `layouts/partials/head/meta/robots.html` + `params.listPaginationMetaRobots` in `config/_default/config.toml`.
 - Open Graph, Twitter, JSON-LD: follow existing patterns in `layouts/partials/head.html` and related partials.
 - New external hosts, share imagery, or scripts must stay coherent with CSP, response headers, and `staticwebapp.config.json`.
 

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -22,8 +22,8 @@ enableRobotsTXT = true
 
 [params]
   dateFormat = "January 2, 2006"
-  # Home list only, page 2+: reduce near-duplicate SERP snippets vs page 1. Per-page `metaRobots` in front matter wins. Set to "" to keep paginated home indexable like page 1.
-  homePaginationMetaRobots = "noindex,follow"
+  # Paginated list pages (home, year/month archives, tags, etc.), page 2+: noindex plus unique meta descriptions. Per-page `metaRobots` in front matter wins. Set to "" to keep page 2+ indexable.
+  listPaginationMetaRobots = "noindex,follow"
   description = "Senior .NET & Azure Engineer specialising in scalable cloud systems, DevOps, and modern architecture. 18+ years delivering production systems across development, infrastructure, and cloud."
   keywords = ".NET, C#, Azure, DevOps, Software Development, Cloud Architecture, CI/CD, Kubernetes, Docker"
   images = ["/images/1922276.jpg"]

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -24,7 +24,7 @@
     {{- $pageDesc = .Title | plainify | htmlUnescape -}}
   {{- end -}}
 {{- else -}}
-  {{- $pageDesc = printf "%s - %s" .Title ($.Site.Params.description | default "") | plainify | htmlUnescape -}}
+  {{- $pageDesc = partial "head/list-page-description" . -}}
 {{- end -}}
 {{- with $keywords -}}
 <meta name="keywords" content="{{ . }}" />

--- a/layouts/partials/head/list-page-description.html
+++ b/layouts/partials/head/list-page-description.html
@@ -1,0 +1,13 @@
+{{- /* Home, section, and taxonomy list pages: site tagline plus optional pagination suffix. */ -}}
+{{- $page := . -}}
+{{- $title := $page.Title -}}
+{{- if and $page.IsHome (eq $title "") -}}
+  {{- $title = $page.Site.Title -}}
+{{- end -}}
+{{- $pageDesc := printf "%s - %s" $title ($page.Site.Params.description | default "") | plainify | htmlUnescape -}}
+{{- with $page.Paginator -}}
+  {{- if gt .PageNumber 1 -}}
+    {{- $pageDesc = printf "%s %s" $pageDesc (i18n "pagination_title" .) -}}
+  {{- end -}}
+{{- end -}}
+{{- return $pageDesc -}}

--- a/layouts/partials/head/meta/robots.html
+++ b/layouts/partials/head/meta/robots.html
@@ -1,9 +1,14 @@
 {{- $content := default $.Site.Params.metaRobots .Params.metaRobots -}}
-{{- $isPaginatedHome := and .IsHome (strings.Contains .RelPermalink "/page/") -}}
-{{- if and (not (isset .Params "metarobots")) $isPaginatedHome -}}
-  {{- $hr := default "" $.Site.Params.homePaginationMetaRobots -}}
-  {{- if ne $hr "" -}}
-    {{- $content = $hr -}}
+{{- $isPaginatedListPage := false -}}
+{{- with .Paginator -}}
+  {{- if gt .PageNumber 1 -}}
+    {{- $isPaginatedListPage = true -}}
+  {{- end -}}
+{{- end -}}
+{{- if and (not (isset .Params "metarobots")) $isPaginatedListPage -}}
+  {{- $lpr := default $.Site.Params.homePaginationMetaRobots $.Site.Params.listPaginationMetaRobots -}}
+  {{- if ne $lpr "" -}}
+    {{- $content = $lpr -}}
   {{- end -}}
 {{- end -}}
 {{- if and (not (and (isset .Params "metarobots") (not .Params.metaRobots))) $content -}}

--- a/layouts/partials/head/schema-collection-page.html
+++ b/layouts/partials/head/schema-collection-page.html
@@ -1,5 +1,5 @@
 {{- $page := .page -}}
-{{- $pageDesc := printf "%s - %s" $page.Title ($page.Site.Params.description | default "") | plainify | htmlUnescape -}}
+{{- $pageDesc := partial "head/list-page-description" $page -}}
 {{- $pageURL := $page.Permalink -}}
 {{- with $page.Paginator -}}
   {{- if gt .PageNumber 1 -}}


### PR DESCRIPTION
Introduce dedicated partials for list page descriptions and meta robots. Update configurations to improve SEO by setting unique meta descriptions for paginated list pages, and applying `noindex` to pages beyond the first. Changes aim to reduce duplicate content in SERP by utilizing the new `list-page-description.html` and modifying `robots.html` logic to dynamically handle pagination attributes.