### PR TITLE
docs: add content suggestion requirement to 30-day schedule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -208,7 +208,7 @@ For Hugo-only edits, **`hugo server -D`** or a production **`hugo`** build remai
 - `playwright.yml` – Full Playwright E2E (`main` pushes → production; PRs into `main` → blog-dev)
 - `playwright-smoke.yml` – PR smoke subset against local Hugo (`@smoke`, `BASE_URL=http://127.0.0.1:1313`)
 - `pa11y-nightly.yml` – Scheduled full-sitemap accessibility scan
-- `issue-schedule.yml` – Weekly LLM planner: open issues → **30-day implementation schedule** tracking issue (`scripts/issue-schedule/`)
+- `issue-schedule.yml` – Weekly LLM planner: open issues → **30-day implementation schedule** tracking issue (`scripts/issue-schedule/`); each week includes ≥1 `[Content Suggestion]` when open
 - `blog-post-idea.yml` – Weekly LLM: catalogue posts + trends → one `[Content Suggestion]` issue (`scripts/blog-post-idea/`)
 - `tech-debt-scan.yml` – Weekly LLM: codebase signals → `tech-debt` issues (`scripts/tech-debt-scan/`)
 - `home-popular-update.yml` – Weekly Cloudflare Web Analytics top pages → `data/home_popular.toml` PR (`scripts/home-popular/`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ After bulk-editing post front matter, run **`npm run check:meta`** before openin
 | develop → main PR | GitHub Actions | `auto-pr.yml` |
 | SEO crawl (Signal Diff) | GitHub Actions | `swa-deploy-nonprod.yml` (blog-dev after deploy) and production SWA workflow; manual `seo-check.yml` |
 | Pa11y nightly | GitHub Actions | `pa11y-nightly.yml` — full sitemap on production |
-| 30-day issue schedule | GitHub Actions | `issue-schedule.yml` — Mondays 09:00 UTC + manual; upserts tracking issue via GitHub Models |
+| 30-day issue schedule | GitHub Actions | `issue-schedule.yml` — Mondays 09:00 UTC + manual; upserts tracking issue via GitHub Models; each week slots ≥1 `[Content Suggestion]` when open |
 | Blog post idea | GitHub Actions | `blog-post-idea.yml` — Wednesdays 09:00 UTC + manual; opens one `[Content Suggestion]` issue via GitHub Models |
 | Tech debt scan | GitHub Actions | `tech-debt-scan.yml` — Fridays 09:00 UTC + manual; opens `tech-debt` issues via GitHub Models |
 | Home popular refresh | GitHub Actions | `home-popular-update.yml` — Mondays 06:30 UTC + manual; Cloudflare Web Analytics top pages → `data/home_popular.toml` PR into `develop` |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ npm run check:meta:fix          # preview description rewrites (--dry-run)
 
 To apply description fixes (write files), run `python scripts/normalize_meta_descriptions.py --root .` (without `--dry-run`). Requires Python 3.11+ on `PATH` (same as the GitHub Actions meta workflows).
 
-**30-day issue schedule:** Mondays (and manual) **`issue-schedule.yml`** reviews open GitHub issues via GitHub Models and upserts a tracking issue titled **30-day implementation schedule**. See [`scripts/issue-schedule/README.md`](scripts/issue-schedule/README.md).
+**30-day issue schedule:** Mondays (and manual) **`issue-schedule.yml`** reviews open GitHub issues via GitHub Models and upserts a tracking issue titled **30-day implementation schedule**, including at least one **`[Content Suggestion]`** per week when open. See [`scripts/issue-schedule/README.md`](scripts/issue-schedule/README.md).
 
 **Blog post idea:** Wednesdays (and manual) **`blog-post-idea.yml`** catalogues published posts, asks GitHub Models for one trend-aware idea, and opens a **`[Content Suggestion]`** issue. See [`scripts/blog-post-idea/README.md`](scripts/blog-post-idea/README.md).
 

--- a/scripts/issue-schedule/README.md
+++ b/scripts/issue-schedule/README.md
@@ -2,6 +2,8 @@
 
 GitHub Actions workflow [`.github/workflows/issue-schedule.yml`](../../.github/workflows/issue-schedule.yml) runs this script every Monday at 09:00 UTC (and on `workflow_dispatch`). It lists open issues, calls a chat model once, and creates or updates the issue titled **30-day implementation schedule**.
 
+**Content cadence:** open issues titled `[Content Suggestion]: …` (from [`blog-post-idea`](../blog-post-idea/)) are surfaced explicitly to the model. The prompt requires **at least one content suggestion in each week** of the plan when enough are open (distinct issues preferred; shortfalls noted when the pool is smaller than four weeks).
+
 Same pattern as Episode Atlas (`EpisodeTracker` `scripts/issue-schedule/`).
 
 ## Authentication (LLM)

--- a/scripts/issue-schedule/prompt.md
+++ b/scripts/issue-schedule/prompt.md
@@ -4,9 +4,14 @@ Context for prioritisation:
 - Content/posts, SEO meta, accessibility, and CI/test fixes are often high leverage.
 - Prefer site overrides under root layouts/assets/static over theme edits.
 - Parkrun generated content and public/ build output are not hand-edited as source of truth.
+- Issues titled `[Content Suggestion]: …` are ready-to-write blog post ideas; treating them as implementable content work keeps the publishing cadence healthy.
 
 Rules:
 - Prefer leaf/implementable issues over umbrellas for implementation slots; umbrellas may appear only as context or parent notes.
+- **Content suggestions (required):** Each week of the plan (Week 1–4) MUST include at least one open `[Content Suggestion]: …` issue as an implementation item when any such issues exist in the JSON.
+  - Prefer a **distinct** content-suggestion issue per week when the open pool allows (≥4).
+  - If fewer open content suggestions than weeks, schedule every available one across as many early weeks as possible, and for remaining weeks note that no unused content suggestion remains (do not invent issues or reuse the same issue in multiple weeks).
+  - If none exist, state that clearly once (do not invent placeholders).
 - Note blockers and dependencies between issues.
 - Do not invent issue numbers — only use numbers from the provided JSON.
 - Skip the schedule tracking issue itself (title "30-day implementation schedule") when ranking work.
@@ -17,3 +22,4 @@ Output format:
 1. A line with the run date (UTC).
 2. A week-bucketed plan for the next ~30 days (Week 1–4 or dated ranges).
 3. For each planned item: issue number (and title), effort guess (S/M/L), and a short rationale.
+4. Ensure each week’s list includes the required content-suggestion item (when available) alongside any other work.

--- a/scripts/issue-schedule/run.mjs
+++ b/scripts/issue-schedule/run.mjs
@@ -20,8 +20,10 @@ import { fileURLToPath } from "node:url";
 
 const TRACKING_TITLE = "30-day implementation schedule";
 const META_LABEL = "meta-umbrella";
+const CONTENT_SUGGESTION_PREFIX = "[Content Suggestion]:";
 const BODY_TRUNCATE = 120;
 const ISSUE_LIMIT = 100;
+const PLAN_WEEKS = 4;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -53,6 +55,12 @@ function truncate(text, max) {
   const t = String(text).trim();
   if (t.length <= max) return t;
   return `${t.slice(0, max)}…`;
+}
+
+function isContentSuggestion(issue) {
+  return String(issue?.title || "")
+    .trim()
+    .startsWith(CONTENT_SUGGESTION_PREFIX);
 }
 
 function normalizeIssues(raw) {
@@ -239,8 +247,15 @@ async function main() {
 
   const issues = normalizeIssues(raw || []);
   const forModel = issues.filter((i) => i.title !== TRACKING_TITLE);
+  const contentSuggestions = forModel.filter(isContentSuggestion);
 
   console.log(`Open issues fetched: ${issues.length} (sending ${forModel.length} to model)`);
+  console.log(
+    `Open content-suggestion issues: ${contentSuggestions.length}` +
+      (contentSuggestions.length
+        ? ` (#${contentSuggestions.map((i) => i.number).join(", #")})`
+        : ""),
+  );
 
   if (forModel.length === 0) {
     fail("No open issues to schedule");
@@ -248,8 +263,22 @@ async function main() {
 
   const runDate = new Date().toISOString().slice(0, 10);
   const systemPrompt = loadPrompt();
+  const contentHint =
+    contentSuggestions.length === 0
+      ? [
+          "Content suggestions: none open.",
+          `Still produce a ${PLAN_WEEKS}-week plan; note that no [Content Suggestion] issues are available this run.`,
+        ].join(" ")
+      : [
+          `Content suggestions (must schedule ≥1 distinct issue per week when the pool allows; ${contentSuggestions.length} open for ${PLAN_WEEKS} weeks):`,
+          contentSuggestions
+            .map((i) => `#${i.number} ${i.title}`)
+            .join("\n"),
+        ].join("\n");
   const userContent = [
     `Run date (UTC): ${runDate}`,
+    "",
+    contentHint,
     "",
     "Open issues JSON (compact):",
     JSON.stringify(forModel),
@@ -267,6 +296,22 @@ async function main() {
 
   if (!schedule.includes("#") && !/\d+/.test(schedule)) {
     fail("LLM output does not look like a schedule (no issue references)");
+  }
+
+  if (contentSuggestions.length > 0) {
+    const scheduledContent = contentSuggestions.filter((i) =>
+      new RegExp(`#${i.number}\\b`).test(schedule),
+    );
+    const needed = Math.min(PLAN_WEEKS, contentSuggestions.length);
+    if (scheduledContent.length < needed) {
+      console.warn(
+        `WARNING: expected at least ${needed} content-suggestion issue(s) in the schedule, found ${scheduledContent.length} (#${scheduledContent.map((i) => i.number).join(", #") || "none"})`,
+      );
+    } else {
+      console.log(
+        `Content suggestions referenced in schedule: ${scheduledContent.length} (≥${needed} required)`,
+      );
+    }
   }
 
   const header = [


### PR DESCRIPTION
Update issue scheduling to ensure each weekly plan includes at least one `[Content Suggestion]` issue, when available. This change aims to maintain a consistent publishing cadence by drawing attention to content-related tasks.

Modify various documentation files to highlight the inclusion of content suggestions in the 30-day issue schedule plan. Update the `run.mjs` script to validate the presence of content-suggestion issues in the generated schedule.

These changes ensure important content ideas are prioritized in the schedule, fostering a regular update rhythm.