### PR TITLE
Bump root nanoid and undici for Dependabot hygiene

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -868,15 +868,6 @@
         "algoliasearch": ">= 4.9.1 < 6"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@floating-ui/core": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
@@ -3487,16 +3478,15 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4687,15 +4677,11 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,10 @@
   },
   "name": "hugo-theme-bootstrap-skeleton",
   "version": "0.1.0",
+  "overrides": {
+    "nanoid": "3.3.18",
+    "undici": "6.28.0"
+  },
   "scripts": {
     "test": "npx playwright test",
     "test:ci": "npx playwright test",


### PR DESCRIPTION
## Summary
- Add npm `overrides` for `nanoid@3.3.18` (CVE-2026-67213) and `undici@6.28.0` (CVE-2026-1526) in the root lockfile used by Playwright/CI tooling.
- Leaves the vendored theme lockfile alone; those alerts remain unused for Hugo/SWA builds.

## Test plan
- [ ] CI `npm ci` / Playwright smoke on this branch succeeds
- [ ] Confirm Dependabot alerts for root `nanoid` and `undici` close after merge
- [ ] Spot-check that theme `package-lock.json` alerts are unchanged (expected)

Made with [Cursor](https://cursor.com)